### PR TITLE
52 bug in qubo class

### DIFF
--- a/src/qiboopt/combinatorial/combinatorial.py
+++ b/src/qiboopt/combinatorial/combinatorial.py
@@ -9,10 +9,7 @@ from qibo.hamiltonians import SymbolicHamiltonian
 from qibo.models.circuit import Circuit
 from qibo.symbols import X, Y, Z
 
-from qiboopt.opt_class.opt_class import (
-    QUBO,
-    LinearProblem,
-)
+from qiboopt.opt_class.opt_class import QUBO, LinearProblem
 
 
 def _calculate_two_to_one(num_cities):

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -225,7 +225,7 @@ class QUBO:
 
         return circuit
 
-    def qubo_to_ising(self, constant=0.0):
+    def qubo_to_ising(self):
         """Convert a QUBO problem to an Ising problem.
 
         Maps a quadratic unconstrained binary optimisation (QUBO) problem defined over binary variables
@@ -238,32 +238,21 @@ class QUBO:
 
              x'  Q  x  = \\text{constant} + s'  J  s + h'  s
 
-        Args:
-            constant (float): Constant offset to be applied to the energy. Defaults to :math:`0.0`.
-
         Returns:
             (dict, dict, float): A 3-tuple containing: ``h``: the linear coefficients of the Ising problem, ``J``:
             the quadratic coefficients of the Ising problem, and constant: the new energy offset.
         """
         h = {}
         J = {}
-        linear_offset = 0.0
-        quadratic_offset = 0.0
+        constant = self.offset
 
         for (u, v), bias in self.Qdict.items():
-            if u == v:
-                h[u] = h.get(u, 0) + bias / 2
-                linear_offset += bias
-
-            else:
-                if bias:
-                    J[(u, v)] = bias / 4
-                h[u] = h.get(u, 0) + bias / 4
-                h[v] = h.get(v, 0) + bias / 4
-                quadratic_offset += bias
-
-        constant += 0.5 * linear_offset + 0.25 * quadratic_offset
-
+            if bias:
+                constant += bias/4
+                h[u] = h.get(u, 0) - bias/4
+                h[v] = h.get(v, 0) - bias/4
+                if u != v:
+                    J[u, v] = bias/4
         return h, J, constant
 
     def construct_symbolic_Hamiltonian_from_QUBO(self):

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -87,7 +87,7 @@ class QUBO:
 
             # next the opt_class biases
             for (u, v), bias in self.J.items():
-                if bias:
+                if bias and u!= v:
                     self.Qdict[(u, v)] = 4.0 * bias
                     self.Qdict[(u, u)] = self.Qdict.get((u, u), 0) - 2.0 * bias
                     self.Qdict[(v, v)] = self.Qdict.get((v, v), 0) - 2.0 * bias

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -80,19 +80,18 @@ class QUBO:
             J = args[1]
             self.h = h
             self.J = J
-
-            # ZC NOTE: Is this correct?
-            self.Qdict = {(v, v): 2.0 * bias for v, bias in h.items()}
+            self.Qdict = {(v, v): -2.0 * bias for v, bias in h.items()}
+            self.n = 0
 
             # next the opt_class biases
-            for (u, v), bias in self.Qdict.items():
+            for (u, v), bias in self.J.items():
                 if bias:
                     self.Qdict[(u, v)] = 4.0 * bias
                     self.Qdict[(u, u)] = self.Qdict.get((u, u), 0) - 2.0 * bias
                     self.Qdict[(v, v)] = self.Qdict.get((v, v), 0) - 2.0 * bias
 
             # finally adjust the offset based on QUBO definitions rather than Ising formulation
-            self.offset += sum(J.values()) - sum(h.values())
+            self.offset += sum(J.values()) + sum(h.values())
         else:
             raise_error(
                 NotImplementedError, "Invalid number of args in the QUBO constructor."

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -86,7 +86,7 @@ class QUBO:
 
             # next the opt_class biases
             for (u, v), bias in self.J.items():
-                if bias and u!= v:
+                if bias and u != v:
                     self.Qdict[(u, v)] = 4.0 * bias
                     self.Qdict[(u, u)] = self.Qdict.get((u, u), 0) - 2.0 * bias
                     self.Qdict[(v, v)] = self.Qdict.get((v, v), 0) - 2.0 * bias
@@ -247,11 +247,11 @@ class QUBO:
 
         for (u, v), bias in self.Qdict.items():
             if bias:
-                constant += bias/4
-                h[u] = h.get(u, 0) - bias/4
-                h[v] = h.get(v, 0) - bias/4
+                constant += bias / 4
+                h[u] = h.get(u, 0) - bias / 4
+                h[v] = h.get(v, 0) - bias / 4
                 if u != v:
-                    J[u, v] = bias/4
+                    J[u, v] = bias / 4
         return h, J, constant
 
     def construct_symbolic_Hamiltonian_from_QUBO(self):

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -83,7 +83,6 @@ class QUBO:
             self.h = h
             self.J = J
             self.Qdict = {(v, v): -2.0 * bias for v, bias in h.items()}
-            self.n = 0
 
             # next the opt_class biases
             for (u, v), bias in self.J.items():

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -78,6 +78,8 @@ class QUBO:
         elif len(args) == 2:
             h = args[0]
             J = args[1]
+            if not all(isinstance(k, int) for k in h.keys()):
+                raise TypeError("All keys in the dictionary must be integers.")
             self.h = h
             self.J = J
             self.Qdict = {(v, v): -2.0 * bias for v, bias in h.items()}

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,7 +1,8 @@
+import numpy as np
 from qibo import Circuit, gates
 from qibo.optimizers import optimize
 from qibo.quantum_info import infidelity
-import numpy as np
+
 
 # custom loss function, computes fidelity
 def myloss(parameters, circuit, target):
@@ -9,9 +10,10 @@ def myloss(parameters, circuit, target):
     final_state = circuit().state()
     return infidelity(final_state, target)
 
+
 nqubits = 6
 dims = 2**nqubits
-nlayers  = 2
+nlayers = 2
 
 # Create variational circuit
 circuit = Circuit(nqubits)
@@ -28,7 +30,9 @@ x0 = np.random.uniform(0, 2 * np.pi, nqubits * (2 * nlayers + 1))
 data = np.random.normal(0, 1, size=dims)
 
 # perform optimization
-best, params, extra = optimize(myloss, x0, args=(circuit, data), method='BFGS', options={'maxiter':10})
+best, params, extra = optimize(
+    myloss, x0, args=(circuit, data), method="BFGS", options={"maxiter": 10}
+)
 
 # set final solution to circuit instance
 circuit.set_parameters(params)
@@ -48,7 +52,3 @@ import itertools
 vec_permutations = itertools.product([0, 1], repeat=3)
 for permutation in vec_permutations:
     print(permutation)
-
-
-
-

--- a/tests/test_combinatorial.py
+++ b/tests/test_combinatorial.py
@@ -10,10 +10,7 @@ from qiboopt.combinatorial.combinatorial import (
     _tsp_mixer,
     _tsp_phaser,
 )
-from qiboopt.opt_class.opt_class import (
-    QUBO,
-    LinearProblem,
-)
+from qiboopt.opt_class.opt_class import QUBO, LinearProblem
 
 
 def test__calculate_two_to_one():

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -60,7 +60,7 @@ def test_qubo_to_ising():
 
     h, J, constant = qp.qubo_to_ising()
 
-    assert h == {0: 1.25, 1: -0.75}
+    assert h == {0: -1.25, 1: 0.75}
     assert J == {(0, 1): 0.25}
     assert constant == 0.25
 

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -6,10 +6,7 @@ from qibo.noise import DepolarizingError, NoiseModel
 from qibo.optimizers import optimize
 from qibo.quantum_info import infidelity
 
-from qiboopt.opt_class.opt_class import (
-    QUBO,
-    LinearProblem,
-)
+from qiboopt.opt_class.opt_class import QUBO, LinearProblem
 
 
 def test_initialization():
@@ -41,13 +38,12 @@ def test_add_multiplication_operators():
     [
         (
             {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
-           {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
+            {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
         ),
         ({(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0}, {3: 1.0, 4: 0.82, 5: 0.23}),
         (15, 13),
     ],
 )
-
 def test_invalid_input_qubo(h, J):
     """Test invalid initialization of the QUBO class"""
     with pytest.raises(TypeError):
@@ -108,7 +104,7 @@ def test_initialization_with_h_and_J():
 
     # Initialize QUBO instance with Ising h and J
     qubo_instance = QUBO(offset, h, J)
-    expected_Qdict = {(0, 0): -3.0, (1, 1): 2.0, (0,1): 2.0}
+    expected_Qdict = {(0, 0): -3.0, (1, 1): 2.0, (0, 1): 2.0}
     assert (
         qubo_instance.Qdict == expected_Qdict
     ), "Qdict should be created based on h and J conversion"

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -41,12 +41,13 @@ def test_add_multiplication_operators():
     [
         (
             {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
-            {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
+           {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
         ),
         ({(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0}, {3: 1.0, 4: 0.82, 5: 0.23}),
         (15, 13),
     ],
 )
+
 def test_invalid_input_qubo(h, J):
     """Test invalid initialization of the QUBO class"""
     with pytest.raises(TypeError):
@@ -107,7 +108,7 @@ def test_initialization_with_h_and_J():
 
     # Initialize QUBO instance with Ising h and J
     qubo_instance = QUBO(offset, h, J)
-    expected_Qdict = {(0, 0): 0.0, (1, 1): 0.0}
+    expected_Qdict = {(0, 0): -3.0, (1, 1): 2.0, (0,1): 2.0}
     assert (
         qubo_instance.Qdict == expected_Qdict
     ), "Qdict should be created based on h and J conversion"
@@ -126,7 +127,7 @@ def test_offset_calculation():
     qubo_instance = QUBO(offset, h, J)
 
     # Expected offset after adjustment: offset + sum(J) - sum(h)
-    expected_offset = offset + sum(J.values()) - sum(h.values())
+    expected_offset = offset + sum(J.values()) + sum(h.values())
 
     # Verify the offset value
     assert (
@@ -141,16 +142,14 @@ def test_isolated_terms_in_h_and_J():
     offset = 1.0
 
     qubo_instance = QUBO(offset, h, J)
-    print(qubo_instance.Qdict)
-    print("check above")
     # Expected Qdict should only contain diagonal terms based on h
-    expected_Qdict = {(0, 0): 0.0, (1, 1): 0.0, (2, 2): 0.0}
+    expected_Qdict = {(0, 0): -3.0, (1, 1): 4.0, (2, 2): -1.0}
     assert (
         qubo_instance.Qdict == expected_Qdict
     ), "Qdict should reflect only h terms when J is empty"
 
     # Expected offset should only adjust based on sum of h values since J is empty
-    expected_offset = offset - sum(h.values())
+    expected_offset = offset + sum(h.values())
     assert (
         qubo_instance.offset == expected_offset
     ), "Offset should adjust only with h values when J is empty"


### PR DESCRIPTION
This pull request fixes the bug in Issue 52. 

We use the convention of x = (1-s)/2 to convert QUBO to Ising  models and also to convert from Ising models to QUBO. 

