### PR TITLE
19 map variables to indices in a qubo

### DIFF
--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -225,7 +225,7 @@ class QUBO:
 
         return circuit
 
-    def qubo_to_ising(self, constant=0.0):
+    def qubo_to_ising(self):
         """Convert a QUBO problem to an Ising problem.
 
         Maps a quadratic unconstrained binary optimisation (QUBO) problem defined over binary variables
@@ -238,32 +238,21 @@ class QUBO:
 
              x'  Q  x  = \\text{constant} + s'  J  s + h'  s
 
-        Args:
-            constant (float): Constant offset to be applied to the energy. Defaults to :math:`0.0`.
-
         Returns:
             (dict, dict, float): A 3-tuple containing: ``h``: the linear coefficients of the Ising problem, ``J``:
             the quadratic coefficients of the Ising problem, and constant: the new energy offset.
         """
         h = {}
         J = {}
-        linear_offset = 0.0
-        quadratic_offset = 0.0
+        constant = self.offset
 
         for (u, v), bias in self.Qdict.items():
-            if u == v:
-                h[u] = h.get(u, 0) + bias / 2
-                linear_offset += bias
-
-            else:
-                if bias:
-                    J[(u, v)] = bias / 4
-                h[u] = h.get(u, 0) + bias / 4
-                h[v] = h.get(v, 0) + bias / 4
-                quadratic_offset += bias
-
-        constant += 0.5 * linear_offset + 0.25 * quadratic_offset
-
+            if bias:
+                constant += bias/4
+                h[u] = h.get(u, 0) - bias/4
+                h[v] = h.get(v, 0) - bias/4
+                if u != v:
+                    J[u, v] = bias/4
         return h, J, constant
 
     def construct_symbolic_Hamiltonian_from_QUBO(self):

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -87,7 +87,7 @@ class QUBO:
 
             # next the opt_class biases
             for (u, v), bias in self.J.items():
-                if bias:
+                if bias and u!= v:
                     self.Qdict[(u, v)] = 4.0 * bias
                     self.Qdict[(u, u)] = self.Qdict.get((u, u), 0) - 2.0 * bias
                     self.Qdict[(v, v)] = self.Qdict.get((v, v), 0) - 2.0 * bias

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -80,19 +80,18 @@ class QUBO:
             J = args[1]
             self.h = h
             self.J = J
-
-            # ZC NOTE: Is this correct?
-            self.Qdict = {(v, v): 2.0 * bias for v, bias in h.items()}
+            self.Qdict = {(v, v): -2.0 * bias for v, bias in h.items()}
+            self.n = 0
 
             # next the opt_class biases
-            for (u, v), bias in self.Qdict.items():
+            for (u, v), bias in self.J.items():
                 if bias:
                     self.Qdict[(u, v)] = 4.0 * bias
                     self.Qdict[(u, u)] = self.Qdict.get((u, u), 0) - 2.0 * bias
                     self.Qdict[(v, v)] = self.Qdict.get((v, v), 0) - 2.0 * bias
 
             # finally adjust the offset based on QUBO definitions rather than Ising formulation
-            self.offset += sum(J.values()) - sum(h.values())
+            self.offset += sum(J.values()) + sum(h.values())
         else:
             raise_error(
                 NotImplementedError, "Invalid number of args in the QUBO constructor."

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -815,3 +815,59 @@ class LinearProblem:
             for j in range(num_cols)
         }
         return QUBO(offset, Qdict)
+
+
+def variable_to_ind(variable_list):
+    '''
+    given a list of variable, returns a dictionary from the variables to integers and also
+    a dictionary to map the integer to the variables
+    Args: a list of objects, typically strings
+    returns:
+    Two dictionaries, one map from the variable to the indices and it performs the reverse
+    Example:
+    .. testcode::
+       variables = ["x1", "x2", "x3"]
+       v2i, i2v = variable_to_ind(variables)
+
+        print(v2i)
+        # >>> {'x1': 0, 'x2': 1, 'x3': 2}
+        print(i2v)
+        # >>> {0: 'x1', 1: 'x2', 2: 'x3'}
+    '''
+    var_to_idx = {var: i for i, var in enumerate(variable_list)}
+    idx_to_var = {i: var for i, var in enumerate(variable_list)}
+    return var_to_idx, idx_to_var
+
+
+def variable_dict_to_ind_dict(variable_dict, var_to_idx):
+    '''
+    This functions take in a dictionary that maps from (variable, variable) to float
+    or variable to float convert the dictionary key to the corresponding indices
+    Args:
+        variable_dict: dictionary
+        var_to_idx: a mapping from the variable to an index
+    Returns:
+        a dictionary that maps from indices to
+    Example:
+    .. testcode::
+    var_to_idx = {'x1': 0, 'x2': 1, 'x3': 2}
+
+    variable_dict = {
+        ('x1', 'x2'): 1.5,
+        ('x2', 'x3'): -0.5,
+        'x3': 2.0
+    }
+
+    ind_dict = variable_dict_to_ind_dict(variable_dict, var_to_idx)
+    print(ind_dict)
+    # >>> {(0, 1): 1.5, (1, 2): -0.5, 2: 2.0}
+    '''
+    ind_dict = {}
+    for key, value in variable_dict.items():
+        if isinstance(key, tuple):
+            ind_key = tuple(var_to_idx[var] for var in key)
+        else:
+            ind_key = var_to_idx[key]
+        ind_dict[ind_key] = value
+    return ind_dict
+

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -78,6 +78,8 @@ class QUBO:
         elif len(args) == 2:
             h = args[0]
             J = args[1]
+            if not all(isinstance(k, int) for k in h.keys()):
+                raise TypeError("All keys in the dictionary must be integers.")
             self.h = h
             self.J = J
             self.Qdict = {(v, v): -2.0 * bias for v, bias in h.items()}

--- a/tests/test_combinatorial.py
+++ b/tests/test_combinatorial.py
@@ -19,10 +19,9 @@ from qiboopt.opt_class.opt_class import (
 def test__calculate_two_to_one():
     num_cities = 3
     result = _calculate_two_to_one(num_cities)
-    expected = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-    assert np.array_equal(
-        result, expected
-    ), "calculate_two_to_one did not return the expected result"
+    expected_array = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    expected_dict = {(i, j): int(expected_array[i, j]) for i in range(num_cities) for j in range(num_cities)}
+    assert (expected_dict == result), "calculate_two_to_one did not return the expected result"
 
 
 def test__tsp_phaser():

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -60,7 +60,7 @@ def test_qubo_to_ising():
 
     h, J, constant = qp.qubo_to_ising()
 
-    assert h == {0: 1.25, 1: -0.75}
+    assert h == {0: -1.25, 1: 0.75}
     assert J == {(0, 1): 0.25}
     assert constant == 0.25
 

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -41,12 +41,13 @@ def test_add_multiplication_operators():
     [
         (
             {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
-            {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
+           {(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0},
         ),
         ({(0, 0): 2.0, (0, 1): 1.0, (1, 1): -2.0}, {3: 1.0, 4: 0.82, 5: 0.23}),
         (15, 13),
     ],
 )
+
 def test_invalid_input_qubo(h, J):
     """Test invalid initialization of the QUBO class"""
     with pytest.raises(TypeError):
@@ -107,7 +108,7 @@ def test_initialization_with_h_and_J():
 
     # Initialize QUBO instance with Ising h and J
     qubo_instance = QUBO(offset, h, J)
-    expected_Qdict = {(0, 0): 0.0, (1, 1): 0.0}
+    expected_Qdict = {(0, 0): -3.0, (1, 1): 2.0, (0,1): 2.0}
     assert (
         qubo_instance.Qdict == expected_Qdict
     ), "Qdict should be created based on h and J conversion"
@@ -126,7 +127,7 @@ def test_offset_calculation():
     qubo_instance = QUBO(offset, h, J)
 
     # Expected offset after adjustment: offset + sum(J) - sum(h)
-    expected_offset = offset + sum(J.values()) - sum(h.values())
+    expected_offset = offset + sum(J.values()) + sum(h.values())
 
     # Verify the offset value
     assert (
@@ -141,16 +142,14 @@ def test_isolated_terms_in_h_and_J():
     offset = 1.0
 
     qubo_instance = QUBO(offset, h, J)
-    print(qubo_instance.Qdict)
-    print("check above")
     # Expected Qdict should only contain diagonal terms based on h
-    expected_Qdict = {(0, 0): 0.0, (1, 1): 0.0, (2, 2): 0.0}
+    expected_Qdict = {(0, 0): -3.0, (1, 1): 4.0, (2, 2): -1.0}
     assert (
         qubo_instance.Qdict == expected_Qdict
     ), "Qdict should reflect only h terms when J is empty"
 
     # Expected offset should only adjust based on sum of h values since J is empty
-    expected_offset = offset - sum(h.values())
+    expected_offset = offset + sum(h.values())
     assert (
         qubo_instance.offset == expected_offset
     ), "Offset should adjust only with h values when J is empty"

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -9,6 +9,8 @@ from qibo.quantum_info import infidelity
 from qiboopt.opt_class.opt_class import (
     QUBO,
     LinearProblem,
+    variable_to_ind,
+    variable_dict_to_ind_dict
 )
 
 
@@ -567,3 +569,20 @@ def test_linear_square():
     expected_offset = 61
     assert Qdict == expected_Qdict
     assert offset == expected_offset
+
+
+def test_variable_to_ind():
+    variable_list = ['x', 'y', 'qubo']
+    v2i, i2v = variable_to_ind(variable_list)
+    assert v2i == {'x': 0, 'y': 1, 'qubo': 2 }
+    assert i2v == {0: 'x', 1: 'y', 2: 'qubo'}
+
+def test_variable_dict_to_ind_dict():
+    variable_dict = {
+        ('x1', 'x2'): 1.5,
+        ('x2', 'x3'): -0.5,
+        'x3': 2.0
+    }
+    var_to_idx = {'x1': 0, 'x2': 1, 'x3': 2}
+    ans = variable_dict_to_ind_dict(variable_dict, var_to_idx)
+    assert ans == {(0, 1): 1.5, (1, 2): -0.5, 2: 2.0}


### PR DESCRIPTION
We introduce functions that take in arbitary names and map it to an indices, this is to prepare for more advanced problems with arbitrary names. 

Currently most of our previous codes take in dictionary of which the keys are integers or tuple of integers, mapping variables names to integers will be a repetitive tasks. 