### PR TITLE
Phase 1 implementation of DQI

### DIFF
--- a/doc/source/api-reference/dqi.rst
+++ b/doc/source/api-reference/dqi.rst
@@ -1,0 +1,120 @@
+.. _dqi:
+
+Decoded Quantum Interferometry
+------------------------------
+
+This module implements **Decoded Quantum Interferometry (DQI)**, the
+non-variational quantum optimisation algorithm of Jordan, Shutty, Wootters,
+Zalcman, Schmidhuber, King, Isakov, Khattar, Babbush,
+*Optimization by Decoded Quantum Interferometry*,
+`arXiv:2408.08292 v5 <https://arxiv.org/abs/2408.08292>`_,
+*Nature* **646**:831-836, 2025.
+
+DQI takes a max-LIN over GF(2) instance — equivalently a max-XOR-SAT
+instance — given by a parity-check matrix :math:`B \in \mathbb{F}_2^{m
+\times n}` and a target :math:`s \in \{0, 1\}^m`, and produces samples
+:math:`x \in \{0, 1\}^n` concentrated on near-optimal solutions of
+
+.. math::
+
+    \max_{x \in \{0, 1\}^n} \#\{i : v_i \cdot x = s_i \pmod 2\},
+
+where :math:`v_i` is the :math:`i`-th row of :math:`B`.
+
+**Algorithm.** Following the construction of arXiv:2408.08292 §8.1.2, the
+DQI circuit acts on :math:`m + n` qubits — an :math:`m`-qubit *error
+register* and an :math:`n`-qubit *solution register*. The procedure is:
+
+1. Prepare the weighted Dicke superposition
+   :math:`\sum_{k=0}^{\ell} w_k \ket{D^m_k}` on the error register, where
+   :math:`w` is the principal eigenvector of the tridiagonal matrix
+   :math:`A^{(m, \ell, 0)}` of paper Eq. 70.
+2. Apply :math:`Z^{s_i}` to error qubit :math:`i` for each :math:`s_i = 1`,
+   where :math:`s` is the right-hand-side target vector.
+3. Reversibly compute :math:`B^\top y` into the solution register via a
+   CNOT network: for every :math:`(i, j)` with :math:`B_{ij} = 1`, apply
+   ``CNOT(error_i, solution_j)``.
+4. Apply the **in-circuit syndrome decoder**: for each ``(y, S)`` pair
+   from the chosen :class:`SyndromeDecoder`, multi-controlled-X on the
+   error qubits in :math:`S`, controlled on the solution register
+   holding :math:`y`. This uncomputes the error register on
+   decoder-success branches.
+5. Apply :math:`H^{\otimes n}` on the solution register.
+6. Measure both registers; **post-select** shots whose error register
+   reads :math:`\ket{0^m}` (paper Fig. 4 caption: "postselect on
+   :math:`\ket{0}`"). The post-selected solution-register samples follow
+   the canonical DQI :math:`|P(f)|^2` distribution **iff** the in-circuit
+   decoder is exact (no LUT collisions on the Dicke support); see
+   :attr:`DQISolver.is_dqi_exact` and
+   :attr:`DQISolver.decoder_success_probability` for the exactness
+   diagnostics.
+
+**Where DQI helps.** DQI gives a provable polynomial speedup on the Optimal
+Polynomial Intersection (OPI) family (Section 6 of arXiv:2408.08292) and
+heuristic advantage on sparse/LDPC max-LIN. For worst-case generic dense
+max-LINSAT, arXiv:2603.04540 gives tight inapproximability results, so this
+implementation should not be presented as a generic dense max-LIN speedup.
+
+**Phase 1 scope.** Currently implemented: :class:`MaxXORSAT` problem class,
+optimal weight vector, weighted Dicke-state preparation, DQI circuit, the
+brute-force lookup-table decoder, and end-to-end :class:`DQISolver`.
+
+**Phase 1 limitations.**
+
+- Practical only for ``m + n <= 16`` on a state-vector simulator.
+- The brute-force amplitude-encoded Dicke prep materialises a dense
+  :math:`2^m \times 2^m` unitary and is hard-capped at ``m = 12``.
+  Replacing this with a count-register + Bartschi-Eidenbenz construction
+  is a future phase.
+- The LUT decoder is exact only when every weight-:math:`\le \ell` error
+  pattern :math:`S` has a distinct syndrome
+  (:attr:`LUTDecoder.is_exact`). When the LUT has collisions, the
+  post-selected samples follow a chosen-S-restricted distribution
+  rather than the canonical :math:`|P(f)|^2`; the analytic post-selection
+  success probability is reported via
+  :attr:`DQISolver.decoder_success_probability`.
+- Noise robustness is open research; ``DQISolver`` accepts a Qibo noise
+  model but does not guarantee results retain DQI's quantitative
+  properties.
+
+MaxXORSAT
+^^^^^^^^^
+
+.. autoclass:: qiboopt.dqi.max_xorsat.MaxXORSAT
+    :members:
+    :member-order: bysource
+
+Optimal weights
+^^^^^^^^^^^^^^^
+
+.. autofunction:: qiboopt.dqi.weights.optimal_weights
+
+Weighted Dicke preparation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: qiboopt.dqi.dicke.weighted_dicke_amplitudes
+
+.. autofunction:: qiboopt.dqi.dicke.dicke_circuit
+
+DQI circuit
+^^^^^^^^^^^
+
+.. autofunction:: qiboopt.dqi.circuit.dqi_circuit
+
+Decoders
+^^^^^^^^
+
+.. autoclass:: qiboopt.dqi.decoders.base.SyndromeDecoder
+    :members:
+
+.. autoclass:: qiboopt.dqi.decoders.lut.LUTDecoder
+    :members:
+
+.. autofunction:: qiboopt.dqi.decoders.get_decoder
+
+Solver
+^^^^^^
+
+.. autoclass:: qiboopt.dqi.solver.DQISolver
+    :members:
+    :member-order: bysource

--- a/doc/source/api-reference/index.rst
+++ b/doc/source/api-reference/index.rst
@@ -7,3 +7,4 @@ API Reference
 
     combinatorial
     opt_class
+    dqi

--- a/poetry.lock
+++ b/poetry.lock
@@ -3857,4 +3857,4 @@ qiboml = ["qiboml", "torch"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "3fcf926b1c0cf00d701d6cf30d06c47c1c221c078fa3b59c7717e1ba039427b0"
+content-hash = "98fb049e973393ca98fe830da1c6019a68558c6fc993924359c1240320cc3833"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{include="qiboopt", from="src"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
 qibo = ">=0.2,<0.3"
+scipy = "^1.13"
 qiboml = {version = ">=0.1", optional = true}
 torch = {version = "^2.7.0", optional = true}
 

--- a/src/qiboopt/__init__.py
+++ b/src/qiboopt/__init__.py
@@ -5,4 +5,4 @@ try:
 except im.PackageNotFoundError:
     __version__ = "0.0.1"
 
-from . import combinatorial, integrations, opt_class
+from . import combinatorial, dqi, integrations, opt_class

--- a/src/qiboopt/dqi/__init__.py
+++ b/src/qiboopt/dqi/__init__.py
@@ -1,0 +1,64 @@
+"""
+Decoded Quantum Interferometry (DQI) for max-LIN over GF(2).
+
+Implements the non-variational quantum optimisation algorithm of Jordan,
+Shutty, Wootters, Zalcman, Schmidhuber, King, Isakov, Khattar, Babbush,
+*Optimization by Decoded Quantum Interferometry*, `arXiv:2408.08292 v5
+<https://arxiv.org/abs/2408.08292>`_, *Nature* **646**:831-836, 2025.
+
+Phase 1 scope:
+
+- :class:`MaxXORSAT` problem class (parity-check matrix + target).
+- Optimal weight vector :func:`optimal_weights` from the tridiagonal
+  eigenvalue problem of Theorem 3.4.
+- :func:`dqi_circuit` builder on ``m + n`` qubits (error + solution
+  registers, with the syndrome decoder compiled into the circuit).
+- :class:`LUTDecoder` brute-force lookup-table decoder.
+- :class:`DQISolver` end-to-end solver, with error-register
+  post-selection and ``is_dqi_exact`` /
+  ``decoder_success_probability`` diagnostics.
+
+Where DQI helps:
+
+- Provable polynomial speedup on the Optimal Polynomial Intersection (OPI)
+  family (Section 6 of arXiv:2408.08292).
+- Heuristic advantage on sparse / LDPC-style max-LIN.
+- Worst-case generic dense max-LINSAT has tight inapproximability results
+  (arXiv:2603.04540), so this implementation should not be presented as a
+  generic dense max-LIN speedup.
+
+Phase 1 limitations:
+
+- Practical only for ``m + n <= 16`` on a state-vector simulator (the DQI
+  circuit acts on the joint error + solution register).
+- The brute-force Dicke prep materialises a dense ``2**m`` x ``2**m``
+  unitary, capping ``m`` at 12; the decoder enumerates all ``S`` of weight
+  ``<= ell``, capping the number of error patterns at :math:`10^6`.
+- The in-circuit LUT decoder is exact only when every weight-:math:`\\le \\ell`
+  error pattern :math:`S` has a distinct syndrome (no collisions on the
+  Dicke support). When it is not, post-selected samples follow a
+  chosen-S-restricted distribution, **not** the canonical
+  :math:`|P(f)|^2`. ``DQISolver`` exposes ``is_dqi_exact`` and
+  ``decoder_success_probability`` to make this observable.
+- No QUBO ``solve_dqi`` entry point (most QUBOs are not faithfully
+  expressible as max-LIN).
+"""
+
+from qiboopt.dqi.circuit import dqi_circuit
+from qiboopt.dqi.decoders import LUTDecoder, SyndromeDecoder, get_decoder
+from qiboopt.dqi.dicke import dicke_circuit, weighted_dicke_amplitudes
+from qiboopt.dqi.max_xorsat import MaxXORSAT
+from qiboopt.dqi.solver import DQISolver
+from qiboopt.dqi.weights import optimal_weights
+
+__all__ = [
+    "MaxXORSAT",
+    "optimal_weights",
+    "dicke_circuit",
+    "weighted_dicke_amplitudes",
+    "dqi_circuit",
+    "DQISolver",
+    "SyndromeDecoder",
+    "LUTDecoder",
+    "get_decoder",
+]

--- a/src/qiboopt/dqi/circuit.py
+++ b/src/qiboopt/dqi/circuit.py
@@ -1,0 +1,146 @@
+"""
+DQI quantum circuit construction.
+
+The DQI circuit acts on :math:`m + n` qubits, organised into two registers:
+
+- **error register**: qubits ``0 .. m - 1``, one per constraint.
+- **solution register**: qubits ``m .. m + n - 1``, one per variable.
+
+Stages:
+
+1. Prepare :math:`\\sum_{k=0}^{\\ell} w_k \\ket{D^m_k}` on the error
+   register.
+2. Apply :math:`Z^{s_i}` to error qubit :math:`i` for each :math:`s_i = 1`.
+3. **B-transpose multiplication**: for every :math:`(i, j)` with
+   :math:`B_{ij} = 1`, apply ``CNOT(error_i, solution_j)``. This computes
+   :math:`\\ket{S}_e \\ket{0}_s \\to \\ket{S}_e \\ket{B^\\top S}_s`.
+4. **In-circuit syndrome decoder**: for each ``(y, S)`` pair from the
+   chosen :class:`SyndromeDecoder`, apply :math:`X` on every error qubit
+   :math:`i` with :math:`S_i = 1`, multi-controlled on the solution
+   register equal to :math:`y` (mixed |0>/|1> controls). This uncomputes
+   the error register on covered syndromes; on un-covered syndromes the
+   error register is left in a non-zero state ("decoder failure"
+   branches).
+5. Apply :math:`H^{\\otimes n}` on the solution register.
+6. Measure the solution register; the bitstring is the candidate
+   :math:`x`.
+
+Reference: Jordan et al., *Optimization by Decoded Quantum
+Interferometry*, `arXiv:2408.08292 v5 <https://arxiv.org/abs/2408.08292>`_,
+*Nature* **646**:831-836, 2025.
+"""
+
+import numpy as np
+from qibo import Circuit, gates
+from qibo.config import raise_error
+
+from qiboopt.dqi.decoders import get_decoder
+from qiboopt.dqi.decoders.base import SyndromeDecoder, validate_decoder_compatibility
+from qiboopt.dqi.dicke import _unitary_with_first_column, weighted_dicke_amplitudes
+from qiboopt.dqi.weights import optimal_weights
+
+
+def dqi_circuit(
+    problem,
+    ell,
+    *,
+    weights=None,
+    decoder="lut",
+    include_measurements=True,
+):
+    r"""Construct the DQI circuit for a :class:`MaxXORSAT` problem.
+
+    Args:
+        problem (:class:`qiboopt.dqi.max_xorsat.MaxXORSAT`): The max-XOR-SAT
+            instance with parity-check matrix :math:`B` and target :math:`s`.
+        ell (int): Hamming-weight cutoff. Must satisfy ``1 <= ell <= problem.m``.
+        weights (np.ndarray, optional): Length-``ell + 1`` weight vector. If
+            ``None``, computed via :func:`qiboopt.dqi.weights.optimal_weights`.
+        decoder (str | :class:`SyndromeDecoder`, optional): Either a registered
+            decoder name (currently only ``"lut"``) or a pre-instantiated
+            :class:`SyndromeDecoder`. Defaults to ``"lut"``.
+        include_measurements (bool, optional): If ``True``, append measurement
+            gates on **all** ``m + n`` qubits (both error and solution
+            registers). The error register is post-selected on
+            :math:`\\ket{0^m}` by :class:`DQISolver`. Defaults to ``True``.
+
+    Returns:
+        :class:`qibo.models.Circuit`: The DQI circuit on ``problem.m +
+        problem.n`` qubits.
+
+    Note:
+        Practical scale on a state-vector simulator is approximately
+        ``problem.m + problem.n <= 16``.
+    """
+    m = problem.m
+    n = problem.n
+    if not isinstance(ell, int):
+        raise_error(TypeError, "ell must be an integer.")
+    if ell < 1 or ell > m:
+        raise_error(
+            ValueError, f"ell must satisfy 1 <= ell <= m, got ell={ell}, m={m}."
+        )
+
+    if weights is None:
+        weights = optimal_weights(m, ell)
+    if len(weights) != ell + 1:
+        raise_error(
+            ValueError,
+            f"weights must have length ell + 1 = {ell + 1}, got {len(weights)}.",
+        )
+
+    if isinstance(decoder, SyndromeDecoder):
+        validate_decoder_compatibility(decoder, problem, ell)
+        decoder_obj = decoder
+    else:
+        decoder_obj = get_decoder(decoder, problem, ell)
+
+    total_qubits = m + n
+    circuit = Circuit(total_qubits)
+
+    # Stage 1: weighted Dicke prep on the error register only.
+    amps = weighted_dicke_amplitudes(m, ell, weights)
+    U_dicke = _unitary_with_first_column(amps)
+    circuit.add(gates.Unitary(U_dicke, *range(m)))
+
+    # Stage 2: phase flips by s on the error register.
+    for i in range(m):
+        if problem.s[i]:
+            circuit.add(gates.Z(i))
+
+    # Stage 3: B-transpose CNOT network: CNOT(error_i, solution_j) for B[i,j]=1.
+    B = problem.B
+    for i in range(m):
+        for j in range(n):
+            if B[i, j]:
+                circuit.add(gates.CNOT(i, m + j))
+
+    # Stage 4: in-circuit syndrome decoder.
+    n_qubits_solution = list(range(m, m + n))
+    for y, S in decoder_obj.decode_table():
+        if not np.any(S):
+            # The all-zeros error pattern leaves the error register at |0>;
+            # nothing to uncompute. Skip to avoid emitting useless multi-CX gates.
+            continue
+        zero_controls = [m + j for j in range(n) if y[j] == 0]
+        # X-conjugation pre-flip so |0> controls fire as expected.
+        for q in zero_controls:
+            circuit.add(gates.X(q))
+        for i in range(m):
+            if S[i]:
+                circuit.add(gates.X(i).controlled_by(*n_qubits_solution))
+        # Unflip to restore the solution register.
+        for q in zero_controls:
+            circuit.add(gates.X(q))
+
+    # Stage 5: Hadamards on the solution register.
+    for j in range(n):
+        circuit.add(gates.H(m + j))
+
+    # Stage 6: measure both registers. The error register is post-selected
+    # on |0> by :class:`DQISolver` to project away decoder-failure branches
+    # (paper §8.1.2 / Fig. 4 caption: "postselect on |0>").
+    if include_measurements:
+        circuit.add(gates.M(*range(m + n)))
+
+    return circuit

--- a/src/qiboopt/dqi/decoders/__init__.py
+++ b/src/qiboopt/dqi/decoders/__init__.py
@@ -1,0 +1,43 @@
+"""
+In-circuit syndrome decoders for Decoded Quantum Interferometry.
+
+A :class:`SyndromeDecoder` produces a table of ``(y, S)`` pairs that the
+DQI circuit consumes to uncompute the m-qubit error register conditional
+on the n-qubit solution register holding ``y``. Decoding is therefore
+performed by the quantum circuit itself; there is no classical
+post-processing step on measurement outcomes.
+
+Phase 1 ships only the brute-force lookup-table decoder
+(:class:`LUTDecoder`).
+"""
+
+from qiboopt.dqi.decoders.base import SyndromeDecoder
+from qiboopt.dqi.decoders.lut import LUTDecoder
+
+DECODER_REGISTRY = {
+    "lut": LUTDecoder,
+}
+
+
+def get_decoder(name, *args, **kwargs):
+    """Instantiate a registered decoder by name.
+
+    Args:
+        name (str): Decoder identifier; currently one of ``"lut"``.
+        args: Forwarded positionally to the decoder constructor.
+        kwargs: Forwarded as keywords to the decoder constructor.
+
+    Returns:
+        :class:`SyndromeDecoder`: Instantiated decoder.
+    """
+    if name not in DECODER_REGISTRY:
+        from qibo.config import raise_error
+
+        raise_error(
+            KeyError,
+            f"Unknown decoder {name!r}; available: {sorted(DECODER_REGISTRY)}.",
+        )
+    return DECODER_REGISTRY[name](*args, **kwargs)
+
+
+__all__ = ["SyndromeDecoder", "LUTDecoder", "DECODER_REGISTRY", "get_decoder"]

--- a/src/qiboopt/dqi/decoders/base.py
+++ b/src/qiboopt/dqi/decoders/base.py
@@ -1,0 +1,94 @@
+"""
+Abstract base class for DQI in-circuit syndrome decoders.
+
+A decoder produces a *table* of (syndrome, error) pairs that the
+:func:`qiboopt.dqi.circuit.dqi_circuit` builder turns into a sequence of
+mixed-control multi-controlled-X gates. The decoder is therefore a
+classical *circuit-construction helper*, not a runtime mapping.
+
+For a max-XOR-SAT instance with parity-check matrix :math:`B \\in
+\\mathbb{F}_2^{m \\times n}`, the table maps each :math:`y \\in \\{0, 1\\}^n`
+to a low-weight :math:`S \\in \\{0, 1\\}^m` satisfying :math:`B^\\top S =
+y \\pmod 2` and :math:`|S| \\le \\ell`. The DQI circuit uses each entry to
+uncompute the m-qubit error register conditional on the n-qubit solution
+register holding ``y``.
+"""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+from qibo.config import raise_error
+
+
+def validate_decoder_compatibility(decoder, problem, ell):
+    """Ensure ``decoder`` was built for the same ``(problem, ell)`` pair.
+
+    A pre-built decoder bound to a different problem or cutoff produces a
+    silently-incorrect DQI circuit (its decode table addresses the wrong
+    parity-check matrix). This helper guards :class:`DQISolver` and
+    :func:`qiboopt.dqi.circuit.dqi_circuit` against that footgun.
+
+    Compatibility holds iff:
+
+    - ``decoder.ell == ell``;
+    - ``decoder.problem is problem`` (identity match), **or**
+    - ``decoder.problem.B`` and ``decoder.problem.s`` are element-wise
+      equal to ``problem.B`` and ``problem.s`` (structural match).
+
+    Args:
+        decoder (:class:`SyndromeDecoder`): The pre-built decoder.
+        problem: The :class:`MaxXORSAT` instance the solver / circuit is
+            being built for.
+        ell (int): The Hamming-weight cutoff being requested.
+
+    Raises:
+        ValueError: If ``decoder`` was built for a different ``(problem,
+        ell)`` pair.
+    """
+    if decoder.ell != ell:
+        raise_error(
+            ValueError,
+            f"Pre-built decoder ell={decoder.ell} does not match requested "
+            f"ell={ell}.",
+        )
+    if decoder.problem is problem:
+        return
+    if not (
+        decoder.problem.B.shape == problem.B.shape
+        and decoder.problem.s.shape == problem.s.shape
+        and np.array_equal(decoder.problem.B, problem.B)
+        and np.array_equal(decoder.problem.s, problem.s)
+    ):
+        raise_error(
+            ValueError,
+            "Pre-built decoder was constructed for a different MaxXORSAT "
+            "instance (B or s differ).",
+        )
+
+
+class SyndromeDecoder(ABC):
+    """Interface for in-circuit DQI decoders.
+
+    A decoder is bound to a specific :class:`MaxXORSAT` instance and a
+    Hamming-weight cutoff :math:`\\ell`.
+
+    Subclasses must implement :meth:`decode_table`, which returns the list
+    of ``(y, S)`` pairs the in-circuit decoder will apply.
+    """
+
+    def __init__(self, problem, ell):
+        self.problem = problem
+        self.ell = ell
+
+    @abstractmethod
+    def decode_table(self):
+        """Return the in-circuit decode table.
+
+        Yields:
+            tuple[np.ndarray, np.ndarray]: ``(y, S)`` pairs where
+            ``y`` is a length-``n`` bitstring (``np.uint8``) and ``S`` is a
+            length-``m`` bitstring (``np.uint8``) with :math:`|S| \\le \\ell`
+            and :math:`B^\\top S = y \\pmod 2`. At most one ``S`` per
+            ``y``; the chosen ``S`` should be the smallest-weight (lex
+            tiebreak).
+        """

--- a/src/qiboopt/dqi/decoders/lut.py
+++ b/src/qiboopt/dqi/decoders/lut.py
@@ -1,0 +1,123 @@
+"""
+Brute-force lookup-table syndrome decoder for the in-circuit DQI decoder.
+
+Phase-1 decoder. For a max-XOR-SAT instance with parity-check matrix
+:math:`B \\in \\mathbb{F}_2^{m \\times n}` and Hamming-weight cutoff
+:math:`\\ell`, the decoder enumerates every :math:`S \\in \\{0, 1\\}^m` with
+:math:`|S| \\le \\ell`, computes the syndrome :math:`y = B^\\top S \\pmod 2`,
+and stores the inverse map :math:`y \\mapsto S`. When several :math:`S`
+yield the same :math:`y` (a *collision*), the entry with the smallest
+:math:`|S|` wins (ties broken by the lexicographic order of :math:`S`).
+
+The total table size is at most :math:`\\sum_{k = 0}^{\\ell} \\binom{m}{k}`
+entries; the decoder is independent of :math:`n`.
+
+**Decoder exactness.** The DQI procedure (paper §8.1.2 / Eqs. 33–34)
+requires that the in-circuit decoder uniquely recover the original
+:math:`S` from :math:`B^\\top S` for every :math:`|S| \\le \\ell`. This
+holds iff the LUT has no collisions, equivalently iff the number of
+chosen LUT entries equals :math:`\\sum_{k=0}^{\\ell} \\binom{m}{k}`. We
+expose this as :attr:`is_exact`. When ``is_exact`` is ``False``, the
+post-selected output of the DQI circuit follows a *modified*
+distribution restricted to the LUT-chosen :math:`S` patterns and is
+**not** the canonical DQI :math:`|P(f)|^2` distribution.
+"""
+
+import itertools
+from math import comb
+
+import numpy as np
+from qibo.config import raise_error
+
+from qiboopt.dqi.decoders.base import SyndromeDecoder
+
+_TABLE_SIZE_LIMIT = 10**6
+
+
+class LUTDecoder(SyndromeDecoder):
+    """Brute-force lookup-table decoder.
+
+    Args:
+        problem (:class:`qiboopt.dqi.max_xorsat.MaxXORSAT`): The max-XOR-SAT
+            instance.
+        ell (int): Hamming-weight cutoff used at circuit construction time.
+
+    Attributes:
+        is_exact (bool): True iff every weight-:math:`\\le \\ell` error
+            pattern :math:`S` has a distinct syndrome :math:`B^\\top S`,
+            i.e. the LUT has no collisions on the Dicke support. The
+            dual-distance condition for this is :math:`2\\ell < d^\\perp`
+            (equivalently :math:`2\\ell + 1 \\le d^\\perp` for integer
+            distances). When ``is_exact`` is ``True``, the in-circuit decoder
+            is the unitary required by the canonical DQI procedure and the
+            post-selected solution-register samples follow :math:`|P(f)|^2`.
+
+    Raises:
+        ValueError: If the projected number of error patterns exceeds
+            an internal safety limit (currently :math:`10^6`).
+    """
+
+    def __init__(self, problem, ell):
+        super().__init__(problem, ell)
+        m = problem.m
+        if ell < 0 or ell > m:
+            raise_error(
+                ValueError,
+                f"ell must satisfy 0 <= ell <= m, got ell={ell}, m={m}.",
+            )
+        n_low_weight = sum(comb(m, k) for k in range(ell + 1))
+        if n_low_weight > _TABLE_SIZE_LIMIT:
+            raise_error(
+                ValueError,
+                f"LUT enumerates {n_low_weight} error patterns, exceeding limit "
+                f"{_TABLE_SIZE_LIMIT}; use a different decoder for m={m}, ell={ell}.",
+            )
+        self._table = self._build_table()
+        self._n_low_weight = n_low_weight
+        self.is_exact = len(self._table) == n_low_weight
+
+    def _build_table(self):
+        """Construct the y -> S map keyed by the packed integer of y.
+
+        Smaller |S| wins per y; ties broken by lexicographic (numpy default)
+        order on the packed S.
+        """
+        problem = self.problem
+        ell = self.ell
+        n = problem.n
+        m = problem.m
+        B = problem.B.astype(np.uint8)
+
+        # y -> (weight, S_packed_int, S_array, y_array)
+        table = {}
+        for k in range(ell + 1):
+            for support in itertools.combinations(range(m), k):
+                S = np.zeros(m, dtype=np.uint8)
+                for i in support:
+                    S[i] = 1
+                y = (B.T @ S) % 2  # length-n syndrome
+                y_key = self._pack(y, n)
+                S_int = self._pack(S, m)
+                prev = table.get(y_key)
+                if prev is None:
+                    table[y_key] = (k, S_int, S, y)
+                elif (k, S_int) < (prev[0], prev[1]):
+                    table[y_key] = (k, S_int, S, y)
+        return table
+
+    @staticmethod
+    def _pack(bits, length):
+        """Pack a bit array (qubit 0 most-significant) into a Python int."""
+        out = 0
+        for i in range(length):
+            out = (out << 1) | int(bits[i])
+        return out
+
+    def decode_table(self):
+        """Return the list of ``(y, S)`` pairs for the in-circuit decoder.
+
+        Returns:
+            list[tuple[np.ndarray, np.ndarray]]: One pair per covered
+            syndrome ``y``. Both ``y`` and ``S`` are ``np.uint8`` arrays.
+        """
+        return [(entry[3].copy(), entry[2].copy()) for entry in self._table.values()]

--- a/src/qiboopt/dqi/dicke.py
+++ b/src/qiboopt/dqi/dicke.py
@@ -1,0 +1,115 @@
+"""
+Weighted Dicke-state preparation for Decoded Quantum Interferometry.
+
+For Phase 1 we use brute-force amplitude encoding via :class:`qibo.gates.Unitary`:
+the :math:`2^m`-dimensional amplitude vector of
+:math:`\\sum_{k=0}^{\\ell} w_k \\ket{D^m_k}` is computed explicitly, then a
+unitary whose first column equals that vector is applied to :math:`\\ket{0^m}`.
+This materialises a dense :math:`2^m \\times 2^m` matrix, so memory grows as
+:math:`O(4^m)`. The implementation is intentionally simple — it matches the
+construction used by the PennyLane DQI demo — and is sufficient for the v1
+practical ceiling of :math:`m \\le 10` once combined with the in-circuit
+decoder. We hard-cap :math:`m` at :data:`_MAX_DICKE_M` to fail loudly rather
+than thrash on out-of-memory matrices.
+
+For larger :math:`m` a count-register + Bartschi-Eidenbenz construction is
+the natural successor (deferred to a future phase).
+"""
+
+import math
+
+import numpy as np
+from qibo import Circuit, gates
+from qibo.config import raise_error
+
+#: Maximum number of error qubits supported by the brute-force amplitude
+#: encoder. Beyond this the dense :math:`2^m \times 2^m` unitary is too large
+#: for typical developer / CI machines.
+_MAX_DICKE_M = 12
+
+
+def weighted_dicke_amplitudes(m, ell, w):
+    r"""Return the :math:`2^m`-dimensional amplitude vector of
+
+    .. math::
+
+        \ket{\psi} = \sum_{k=0}^{\ell} w_k \ket{D^m_k}
+                  = \sum_{k=0}^{\ell} \frac{w_k}{\sqrt{\binom{m}{k}}}
+                    \sum_{|S| = k} \ket{S}.
+
+    Basis ordering follows Qibo's convention: the integer index of a
+    computational-basis state encodes the bitstring with qubit ``0`` as the
+    most significant bit.
+
+    Args:
+        m (int): Number of qubits in the Dicke register.
+        ell (int): Hamming-weight cutoff. Must satisfy ``1 <= ell <= m``.
+        w (np.ndarray): Weights of length ``ell + 1``. Need not be unit-normalised
+            on input; the returned vector is normalised to unit :math:`\\ell^2`
+            norm.
+
+    Returns:
+        np.ndarray: Complex amplitude vector of length ``2 ** m``.
+    """
+    if len(w) != ell + 1:
+        raise_error(
+            ValueError,
+            f"w must have length ell + 1 = {ell + 1}, got {len(w)}.",
+        )
+    if ell < 1 or ell > m:
+        raise_error(
+            ValueError, f"ell must satisfy 1 <= ell <= m, got ell={ell}, m={m}."
+        )
+    if m > _MAX_DICKE_M:
+        raise_error(
+            ValueError,
+            f"Brute-force Dicke prep is capped at m <= {_MAX_DICKE_M} (got m={m}). "
+            "A count-register + Bartschi-Eidenbenz construction is the planned "
+            "successor for larger m.",
+        )
+
+    amps = np.zeros(2**m, dtype=complex)
+    for state in range(2**m):
+        k = bin(state).count("1")
+        if k <= ell:
+            amps[state] = w[k] / math.sqrt(math.comb(m, k))
+    norm = np.linalg.norm(amps)
+    if norm == 0:
+        raise_error(ValueError, "All weights are zero; cannot prepare a state.")
+    return amps / norm
+
+
+def _unitary_with_first_column(v):
+    """Return a unitary matrix whose first column equals the unit vector ``v``.
+
+    Implemented by completing ``v`` to an orthonormal basis via a stable
+    Householder-augmented QR factorisation.
+    """
+    d = v.shape[0]
+    M = np.eye(d, dtype=complex)
+    M[:, 0] = v
+    Q, R = np.linalg.qr(M)
+    # Fix sign so that Q[:, 0] equals v (np.linalg.qr is sign-ambiguous).
+    phase = R[0, 0] / abs(R[0, 0]) if abs(R[0, 0]) > 0 else 1.0
+    Q = Q * np.conj(phase)
+    return Q
+
+
+def dicke_circuit(m, ell, w):
+    r"""Build a Qibo circuit that prepares
+    :math:`\sum_{k=0}^{\ell} w_k \ket{D^m_k}` on ``m`` qubits.
+
+    Args:
+        m (int): Number of qubits in the Dicke register.
+        ell (int): Hamming-weight cutoff.
+        w (np.ndarray): Weights of length ``ell + 1``.
+
+    Returns:
+        :class:`qibo.models.Circuit`: A circuit on ``m`` qubits that prepares
+        the weighted Dicke superposition starting from :math:`\ket{0^m}`.
+    """
+    amps = weighted_dicke_amplitudes(m, ell, w)
+    U = _unitary_with_first_column(amps)
+    circuit = Circuit(m)
+    circuit.add(gates.Unitary(U, *range(m)))
+    return circuit

--- a/src/qiboopt/dqi/max_xorsat.py
+++ b/src/qiboopt/dqi/max_xorsat.py
@@ -1,0 +1,247 @@
+"""
+Max-LIN over GF(2) / max-XOR-SAT problem class for Decoded Quantum
+Interferometry.
+"""
+
+import itertools
+
+import numpy as np
+from qibo.config import raise_error
+
+
+def _coerce_binary(arr_like, name):
+    """Validate that every entry is exactly ``0`` or ``1`` and return a
+    ``uint8`` ndarray.
+
+    The check runs on the raw array *before* any ``uint8`` cast, so
+    out-of-range integers (negative or > 1) and non-integer floats are
+    rejected rather than silently wrapped modulo 256.
+    """
+    arr_raw = np.asarray(arr_like)
+    if not np.all((arr_raw == 0) | (arr_raw == 1)):
+        raise_error(
+            ValueError,
+            f"{name} entries must be exactly 0 or 1; got values outside that set.",
+        )
+    return arr_raw.astype(np.uint8)
+
+
+class MaxXORSAT:
+    r"""A max-LIN-over-GF(2) (a.k.a. max-XOR-SAT) optimisation problem.
+
+    Given a parity-check matrix :math:`B \in \mathbb{F}_2^{m \times n}` and a
+    target :math:`s \in \{0, 1\}^m`, the goal is to find :math:`x \in
+    \{0, 1\}^n` maximising the number of constraints
+    :math:`v_i \cdot x = s_i \pmod 2` that are satisfied, where :math:`v_i`
+    is the :math:`i`-th row of :math:`B`.
+
+    This is the native input class for Decoded Quantum Interferometry (DQI),
+    introduced in Jordan et al., *Optimization by Decoded Quantum
+    Interferometry*, `arXiv:2408.08292 v5
+    <https://arxiv.org/abs/2408.08292>`_, *Nature* **646**:831-836, 2025.
+
+    Note:
+        DQI on a state-vector simulator is practical only for instances with
+        ``m + n <= 16`` (the DQI circuit acts on the joint
+        :math:`m + n`-qubit register). The brute-force amplitude-encoded
+        Dicke prep additionally hard-caps :math:`m` at 12 because it
+        materialises a dense :math:`2^m \times 2^m` unitary.
+
+    Args:
+        B (np.ndarray): Parity-check matrix of shape ``(m, n)`` with
+            ``uint8`` / boolean entries in :math:`\{0, 1\}`.
+        s (np.ndarray): Target vector of length ``m`` with entries in
+            :math:`\{0, 1\}`.
+
+    Example:
+        .. testcode::
+
+            import numpy as np
+            from qiboopt.dqi.max_xorsat import MaxXORSAT
+
+            B = np.array([[1, 1, 0],
+                          [0, 1, 1],
+                          [1, 0, 1]], dtype=np.uint8)
+            s = np.array([1, 0, 1], dtype=np.uint8)
+            problem = MaxXORSAT(B, s)
+            print(problem.n, problem.m)
+
+        .. testoutput::
+
+            3 3
+
+        .. testcode::
+
+            print(problem.evaluate(np.array([1, 0, 0], dtype=np.uint8)))
+
+        .. testoutput::
+
+            3
+    """
+
+    def __init__(self, B, s):
+        # Shape checks first so we always have a meaningful error message.
+        B_raw = np.asarray(B)
+        s_raw = np.asarray(s)
+        if B_raw.ndim != 2:
+            raise_error(ValueError, f"B must be 2-D, got shape {B_raw.shape}.")
+        if s_raw.ndim != 1:
+            raise_error(ValueError, f"s must be 1-D, got shape {s_raw.shape}.")
+        if B_raw.shape[0] != s_raw.shape[0]:
+            raise_error(
+                ValueError,
+                f"B and s must have matching first dimension, got "
+                f"{B_raw.shape[0]} != {s_raw.shape[0]}.",
+            )
+        # Value validation runs on the raw array; out-of-range ints and
+        # non-integer floats are rejected before any uint8 cast.
+        self.B = _coerce_binary(B_raw, "B")
+        self.s = _coerce_binary(s_raw, "s")
+
+    @property
+    def m(self):
+        """Number of constraints."""
+        return self.B.shape[0]
+
+    @property
+    def n(self):
+        """Number of variables."""
+        return self.B.shape[1]
+
+    def evaluate(self, x):
+        """Number of constraints satisfied by the candidate ``x``.
+
+        Args:
+            x (np.ndarray): Binary vector of length ``n``.
+
+        Returns:
+            int: Number of constraints :math:`v_i \\cdot x = s_i \\pmod 2`
+            that hold.
+        """
+        x_raw = np.asarray(x)
+        if x_raw.shape != (self.n,):
+            raise_error(
+                ValueError,
+                f"x must have shape ({self.n},), got {x_raw.shape}.",
+            )
+        x_arr = _coerce_binary(x_raw, "x")
+        residual = (self.B @ x_arr + self.s) % 2
+        return int(self.m - residual.sum())
+
+    def brute_force(self):
+        """Find the optimum by exhaustive enumeration. Use only for ``n <= 20``.
+
+        Returns:
+            tuple: A pair ``(x, value)`` where ``x`` is the optimal binary
+            vector (as ``np.ndarray``) and ``value`` the number of satisfied
+            constraints.
+        """
+        if self.n > 20:
+            raise_error(
+                ValueError,
+                f"brute_force is only intended for n <= 20, got n = {self.n}.",
+            )
+        best_x = None
+        best_value = -1
+        for bits in itertools.product([0, 1], repeat=self.n):
+            x = np.array(bits, dtype=np.uint8)
+            value = self.evaluate(x)
+            if value > best_value:
+                best_value = value
+                best_x = x
+        return best_x, best_value
+
+    def to_qubo(self, scale=1.0):
+        """Express the max-XOR-SAT objective as a QUBO.
+
+        Each parity constraint :math:`v_i \\cdot x = s_i` is rewritten as a
+        quadratic penalty :math:`(v_i \\cdot x - s_i)^2 \\bmod 2` and then
+        linearised. Minimising the resulting QUBO is equivalent to maximising
+        the number of satisfied constraints (up to a constant offset).
+
+        Args:
+            scale (float): Multiplicative factor applied to all coefficients.
+
+        Returns:
+            :class:`qiboopt.opt_class.opt_class.QUBO`: QUBO whose minimiser
+            equals the max-XOR-SAT maximiser.
+        """
+        from qiboopt.opt_class.opt_class import QUBO
+
+        Qdict = {}
+        offset = 0.0
+        for i in range(self.m):
+            row = np.flatnonzero(self.B[i])
+            target = int(self.s[i])
+            # (sum_{j in row} x_j - target)^2 expanded over reals; under
+            # x_j in {0,1} we then reduce to GF(2) by adding -2 for each pair
+            # of distinct indices in row that both equal 1, mod 2.
+            # The standard trick: penalty for parity constraint is
+            #   P_i(x) = sum_{j in row} x_j - 2 * sum_{j<k in row} x_j x_k
+            # gives parity(x|row) but only for two-variable rows. For general
+            # row weight w we lift via auxiliary booleans; for w<=2 (e.g.
+            # MaxCut) the direct expansion below is exact.
+            if len(row) == 1:
+                j = int(row[0])
+                if target == 0:
+                    Qdict[(j, j)] = Qdict.get((j, j), 0.0) + scale
+                else:
+                    Qdict[(j, j)] = Qdict.get((j, j), 0.0) - scale
+                    offset += scale
+            elif len(row) == 2:
+                j, k = int(row[0]), int(row[1])
+                # constraint x_j XOR x_k = target
+                # XOR expressed as x_j + x_k - 2 x_j x_k
+                # we want to penalise (x_j XOR x_k) != target, i.e. cost
+                # equals 1 when XOR != target. Reformulating as a linear
+                # combination gives the closed form below.
+                if target == 0:
+                    # penalise XOR=1: cost = x_j + x_k - 2 x_j x_k
+                    Qdict[(j, j)] = Qdict.get((j, j), 0.0) + scale
+                    Qdict[(k, k)] = Qdict.get((k, k), 0.0) + scale
+                    key = (min(j, k), max(j, k))
+                    Qdict[key] = Qdict.get(key, 0.0) - 2.0 * scale
+                else:
+                    # penalise XOR=0: cost = 1 - (x_j + x_k - 2 x_j x_k)
+                    offset += scale
+                    Qdict[(j, j)] = Qdict.get((j, j), 0.0) - scale
+                    Qdict[(k, k)] = Qdict.get((k, k), 0.0) - scale
+                    key = (min(j, k), max(j, k))
+                    Qdict[key] = Qdict.get(key, 0.0) + 2.0 * scale
+            else:
+                raise_error(
+                    NotImplementedError,
+                    f"to_qubo currently supports row weights <= 2; row {i} has weight {len(row)}.",
+                )
+        return QUBO(offset, Qdict)
+
+    @classmethod
+    def random_sparse(cls, n, m, row_weight, *, seed=None):
+        """Generate a random sparse max-XOR-SAT instance.
+
+        Each of the ``m`` rows of :math:`B` has exactly ``row_weight``
+        non-zero entries placed uniformly at random; ``s`` is uniform on
+        :math:`\\{0, 1\\}^m`.
+
+        Args:
+            n (int): Number of variables.
+            m (int): Number of constraints.
+            row_weight (int): Number of non-zero entries in each row of
+                :math:`B`. Must satisfy ``1 <= row_weight <= n``.
+            seed (int, optional): Seed for ``numpy.random.default_rng``.
+
+        Returns:
+            :class:`MaxXORSAT`: Random sparse instance.
+        """
+        if row_weight < 1 or row_weight > n:
+            raise_error(
+                ValueError,
+                f"row_weight must satisfy 1 <= row_weight <= n, got {row_weight}.",
+            )
+        rng = np.random.default_rng(seed)
+        B = np.zeros((m, n), dtype=np.uint8)
+        for i in range(m):
+            cols = rng.choice(n, size=row_weight, replace=False)
+            B[i, cols] = 1
+        s = rng.integers(0, 2, size=m, dtype=np.uint8)
+        return cls(B, s)

--- a/src/qiboopt/dqi/solver.py
+++ b/src/qiboopt/dqi/solver.py
@@ -1,0 +1,253 @@
+"""
+Top-level DQI solver: build the (m + n)-qubit circuit, sample the
+solution register, return the best candidate.
+"""
+
+from math import comb
+
+import numpy as np
+from qibo.backends import _check_backend
+from qibo.config import raise_error
+
+from qiboopt.dqi.circuit import dqi_circuit
+from qiboopt.dqi.decoders import get_decoder
+from qiboopt.dqi.decoders.base import SyndromeDecoder, validate_decoder_compatibility
+from qiboopt.dqi.weights import optimal_weights
+
+
+class DQISolver:
+    r"""Decoded Quantum Interferometry solver for a max-XOR-SAT instance.
+
+    Builds the DQI circuit on ``problem.m + problem.n`` qubits — error
+    register on the first :math:`m`, solution register on the last
+    :math:`n` — executes it under a Qibo backend, post-selects the error
+    register on :math:`\ket{0^m}`, and returns the candidate :math:`x`
+    measured directly from the solution register. The classical decoder
+    is consumed at *circuit-construction* time (its ``decode_table`` is
+    compiled into in-circuit multi-controlled gates); there is no
+    classical post-processing of measurement outcomes beyond the
+    error-register post-selection.
+
+    **DQI exactness.** The canonical DQI procedure of Jordan et al.
+    requires that the in-circuit decoder uniquely recover :math:`S` from
+    :math:`B^\top S` for every :math:`|S| \le \ell`. When that holds
+    (:attr:`is_dqi_exact` is ``True``), the post-selected solution-register
+    samples follow :math:`|P(f)|^2`, the canonical DQI distribution. When
+    it does not (the LUT has collisions on the Dicke support), the
+    post-selected samples follow a *modified* distribution restricted to
+    the LUT-chosen :math:`S` patterns; these may still concentrate near
+    optima but lose the paper's quantitative guarantees.
+
+    Args:
+        problem (:class:`qiboopt.dqi.max_xorsat.MaxXORSAT`): The max-XOR-SAT
+            instance.
+        ell (int): Hamming-weight cutoff for the DQI superposition. Must
+            satisfy ``1 <= ell <= problem.m``.
+        decoder (str | :class:`SyndromeDecoder`, optional): Either a
+            registered decoder name (currently only ``"lut"``) or a
+            pre-instantiated :class:`SyndromeDecoder`. Defaults to
+            ``"lut"``.
+        weights (np.ndarray, optional): Length-``ell + 1`` weight vector. If
+            ``None``, the optimal weights are computed via
+            :func:`qiboopt.dqi.weights.optimal_weights`.
+        backend: Qibo backend to execute the circuit. If ``None``, Qibo's
+            default backend is used.
+        noise_model: Optional Qibo noise model attached to circuit execution.
+            DQI noise robustness is open research; passing a noise model
+            works mechanically but the resulting samples are not guaranteed
+            to retain DQI's quantitative properties. See arXiv:2511.20016
+            (kernelized DQI) for ongoing work.
+
+    Note:
+        Practical scale on a state-vector simulator is approximately
+        ``problem.m + problem.n <= 16``.
+    """
+
+    def __init__(
+        self,
+        problem,
+        ell,
+        *,
+        decoder="lut",
+        weights=None,
+        backend=None,
+        noise_model=None,
+    ):
+        if ell < 1 or ell > problem.m:
+            raise_error(
+                ValueError,
+                f"ell must satisfy 1 <= ell <= m, got ell={ell}, m={problem.m}.",
+            )
+        self.problem = problem
+        self.ell = ell
+        if weights is None:
+            weights_arr = optimal_weights(problem.m, ell)
+        else:
+            weights_arr = np.asarray(weights)
+            if np.iscomplexobj(weights_arr) and not np.allclose(weights_arr.imag, 0):
+                raise_error(
+                    ValueError,
+                    "weights must be real-valued; got complex array with "
+                    "non-zero imaginary part.",
+                )
+            weights_arr = np.asarray(weights_arr.real, dtype=float)
+            if weights_arr.ndim != 1 or weights_arr.shape[0] != ell + 1:
+                raise_error(
+                    ValueError,
+                    f"weights must be a 1-D array of length ell + 1 = {ell + 1}, "
+                    f"got shape {weights_arr.shape}.",
+                )
+            if not np.all(np.isfinite(weights_arr)):
+                raise_error(
+                    ValueError,
+                    "weights must contain only finite values; got NaN or inf.",
+                )
+        norm = float(np.linalg.norm(weights_arr))
+        if norm == 0:
+            raise_error(ValueError, "weights must have non-zero norm.")
+        # Normalise to match the circuit's auto-normalisation in
+        # weighted_dicke_amplitudes; this keeps decoder_success_probability
+        # in [0, 1] regardless of how the caller scales the input.
+        self.weights = weights_arr / norm
+        if isinstance(decoder, SyndromeDecoder):
+            validate_decoder_compatibility(decoder, problem, ell)
+            self.decoder = decoder
+        else:
+            self.decoder = get_decoder(decoder, problem, ell)
+        self.backend = _check_backend(backend)
+        self.noise_model = noise_model
+
+    @property
+    def is_dqi_exact(self):
+        """``True`` iff the in-circuit decoder uniquely recovers every
+        weight-:math:`\\le \\ell` :math:`S` from its syndrome.
+
+        Equivalent to the decoder's :attr:`is_exact`. When ``False``, the
+        post-selected samples follow a chosen-S-restricted distribution,
+        not the canonical DQI :math:`|P(f)|^2`.
+        """
+        return getattr(self.decoder, "is_exact", None)
+
+    @property
+    def decoder_success_probability(self):
+        r"""Analytic probability that the in-circuit decoder succeeds
+        (i.e. that a shot will pass error-register post-selection).
+
+        Computed as :math:`\sum_{(y, S) \in \mathrm{LUT}} w_{|S|}^2 /
+        \binom{m}{|S|}`. Equals 1 iff :attr:`is_dqi_exact`. The empirical
+        ``postselect_success_rate`` from a real run should match this to
+        within sampling noise.
+        """
+        m = self.problem.m
+        total = 0.0
+        for _, S in self.decoder.decode_table():
+            k = int(S.sum())
+            total += float(self.weights[k]) ** 2 / comb(m, k)
+        return total
+
+    def _build_circuit(self):
+        return dqi_circuit(
+            self.problem,
+            self.ell,
+            weights=self.weights,
+            decoder=self.decoder,
+            include_measurements=True,
+        )
+
+    def sample(self, nshots):
+        """Run the DQI circuit, post-select on the error register, and
+        return solution-register samples.
+
+        The DQI procedure (paper §8.1.2 / Fig. 4) leaves the m-qubit error
+        register in :math:`\\ket{0^m}` on branches where the in-circuit
+        decoder succeeds; on failure branches the error register is in a
+        non-zero state that contaminates the solution-register marginal.
+        We post-select shots on ``error register == 0`` to recover the
+        clean (modified-)DQI distribution.
+
+        Args:
+            nshots (int): Number of measurement shots.
+
+        Returns:
+            dict: A dictionary with keys
+
+            - ``"candidates"``: ``(nkept, n)`` ``np.uint8`` array of
+              post-selected ``x`` bitstrings (one row per kept shot).
+              Empty if every shot's error register read non-zero.
+            - ``"raw_samples"``: ``(nshots, m + n)`` ``np.uint8`` array of
+              all shot outcomes (error register first, then solution
+              register), retained for diagnostics.
+            - ``"postselect_success_rate"``: float in :math:`[0, 1]`,
+              empirical fraction of shots whose error register read
+              all-zeros.
+            - ``"decoder_success_probability"``: float in :math:`[0, 1]`,
+              analytic post-selection success probability. Equal to 1 iff
+              the LUT has no collisions on the Dicke support.
+            - ``"is_dqi_exact"``: bool, ``True`` iff
+              ``decoder_success_probability == 1`` (no LUT collisions).
+              Marks whether the post-selected samples follow the
+              canonical DQI :math:`|P(f)|^2` distribution or a
+              chosen-S-restricted variant.
+            - ``"shots"``: ``nshots`` (echo back).
+            - ``"shots_kept"``: number of post-selected shots.
+        """
+        if nshots <= 0:
+            raise_error(ValueError, f"nshots must be positive, got {nshots}.")
+        circuit = self._build_circuit()
+        if self.noise_model is not None:
+            circuit = self.noise_model.apply(circuit)
+        result = self.backend.execute_circuit(circuit, nshots=nshots)
+        raw_samples = np.asarray(result.samples(binary=True), dtype=np.uint8)
+        m, _ = self.problem.m, self.problem.n
+        error_bits = raw_samples[:, :m]
+        solution_bits = raw_samples[:, m:]
+        passed = error_bits.sum(axis=1) == 0
+        candidates = solution_bits[passed]
+        return {
+            "candidates": candidates,
+            "raw_samples": raw_samples,
+            "postselect_success_rate": float(passed.mean()),
+            "decoder_success_probability": self.decoder_success_probability,
+            "is_dqi_exact": self.is_dqi_exact,
+            "shots": nshots,
+            "shots_kept": int(passed.sum()),
+        }
+
+    def solve(self, nshots):
+        """Run :meth:`sample` and return the best post-selected candidate.
+
+        Args:
+            nshots (int): Number of measurement shots.
+
+        Returns:
+            dict: A dictionary with keys
+
+            - ``"best_x"``: the candidate ``x`` (as ``np.uint8`` array)
+              maximising :meth:`MaxXORSAT.evaluate`. ``None`` if every
+              shot failed post-selection.
+            - ``"best_value"``: the corresponding number of satisfied
+              constraints, or ``-1`` if no shot passed post-selection.
+            - ``"postselect_success_rate"``: float.
+            - ``"decoder_success_probability"``: float.
+            - ``"is_dqi_exact"``: bool.
+            - ``"shots"``: ``nshots``.
+            - ``"shots_kept"``: number of post-selected shots.
+        """
+        out = self.sample(nshots)
+        candidates = out["candidates"]
+        best_x = None
+        best_value = -1
+        for x in candidates:
+            value = self.problem.evaluate(x)
+            if value > best_value:
+                best_value = value
+                best_x = x
+        return {
+            "best_x": best_x,
+            "best_value": best_value,
+            "postselect_success_rate": out["postselect_success_rate"],
+            "decoder_success_probability": out["decoder_success_probability"],
+            "is_dqi_exact": out["is_dqi_exact"],
+            "shots": nshots,
+            "shots_kept": out["shots_kept"],
+        }

--- a/src/qiboopt/dqi/weights.py
+++ b/src/qiboopt/dqi/weights.py
@@ -1,0 +1,70 @@
+"""
+Optimal interference weights for Decoded Quantum Interferometry.
+"""
+
+import numpy as np
+from qibo.config import raise_error
+from scipy.linalg import eigh_tridiagonal
+
+
+def optimal_weights(m, ell):
+    r"""Compute the optimal DQI interference weights :math:`w_0, \ldots, w_\ell`.
+
+    These are the amplitudes used in the weighted-Dicke superposition
+    :math:`\sum_{k=0}^{\ell} w_k \ket{D^m_k}` that prepares the DQI state
+    achieving the maximum expected energy ratio at cutoff :math:`\ell` on a
+    max-LIN problem with :math:`m` constraints. Following Theorem 3.4 of
+    Jordan et al. (`arXiv:2408.08292 v5
+    <https://arxiv.org/abs/2408.08292>`_, *Nature* **646**:831-836, 2025),
+    the optimum is the top eigenvector of the symmetric tridiagonal matrix
+    :math:`A` with entries
+
+    .. math::
+
+        A_{k, k+1} = A_{k+1, k} = \sqrt{(k + 1)(m - k)},
+        \quad k = 0, \ldots, \ell - 1,
+
+    and zeros on the diagonal.
+
+    The returned vector is unit-normalised and sign-fixed so that
+    :math:`w_0 > 0`.
+
+    Args:
+        m (int): Number of constraints in the max-LIN instance.
+        ell (int): Hamming-weight cutoff of the DQI superposition. Must satisfy
+            ``0 < ell <= m``.
+
+    Returns:
+        np.ndarray: Vector of length ``ell + 1`` containing the optimal
+        weights.
+
+    Example:
+        .. testcode::
+
+            from qiboopt.dqi.weights import optimal_weights
+            import numpy as np
+
+            w = optimal_weights(m=4, ell=2)
+            print(np.round(w, 4))
+
+        .. testoutput::
+
+            [0.4472 0.7071 0.5477]
+    """
+    if not isinstance(m, int) or not isinstance(ell, int):
+        raise_error(TypeError, "m and ell must be integers.")
+    if m <= 0:
+        raise_error(ValueError, f"m must be positive, got {m}.")
+    if ell <= 0 or ell > m:
+        raise_error(ValueError, f"ell must satisfy 0 < ell <= m, got ell={ell}, m={m}.")
+
+    off = np.array(
+        [np.sqrt((k + 1) * (m - k)) for k in range(ell)],
+        dtype=float,
+    )
+    diag = np.zeros(ell + 1, dtype=float)
+    eigvals, eigvecs = eigh_tridiagonal(diag, off)
+    w = eigvecs[:, -1]
+    if w[0] < 0:
+        w = -w
+    return w

--- a/tests/test_dqi_circuit.py
+++ b/tests/test_dqi_circuit.py
@@ -50,10 +50,18 @@ def test_circuit_measures_all_qubits_for_postselect():
 
 def test_invalid_ell():
     problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(TypeError):
+        dqi_circuit(problem, ell=1.0)
     with pytest.raises(ValueError):
         dqi_circuit(problem, ell=0)
     with pytest.raises(ValueError):
         dqi_circuit(problem, ell=problem.m + 1)
+
+
+def test_circuit_rejects_wrong_length_weights():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        dqi_circuit(problem, ell=2, weights=np.array([1.0, 0.0]))
 
 
 def test_circuit_rejects_decoder_for_different_problem():

--- a/tests/test_dqi_circuit.py
+++ b/tests/test_dqi_circuit.py
@@ -1,0 +1,208 @@
+"""Tests for qiboopt.dqi.circuit."""
+
+import math
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.circuit import dqi_circuit
+from qiboopt.dqi.max_xorsat import MaxXORSAT
+from qiboopt.dqi.weights import optimal_weights
+
+
+def _binary_krawtchouk(k, d, m):
+    """Binary Krawtchouk polynomial K_k(d; m) = sum_j (-1)^j C(d,j) C(m-d, k-j)."""
+    total = 0
+    for j in range(k + 1):
+        total += (-1) ** j * math.comb(d, j) * math.comb(m - d, k - j)
+    return total
+
+
+def test_circuit_qubit_count():
+    """Circuit acts on m + n qubits."""
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    circuit = dqi_circuit(problem, ell=2)
+    assert circuit.nqubits == problem.m + problem.n
+
+
+def test_circuit_no_measurements():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    circuit = dqi_circuit(problem, ell=2, include_measurements=False)
+    assert all(g.name != "measure" for g in circuit.queue)
+
+
+def test_circuit_measures_all_qubits_for_postselect():
+    """include_measurements=True measures ALL m + n qubits.
+
+    The error register is post-selected on |0> by DQISolver to project away
+    decoder-failure branches (paper §8.1.2 / Fig. 4 caption: "postselect on |0>").
+    """
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    circuit = dqi_circuit(problem, ell=2, include_measurements=True)
+    measure_gates = [g for g in circuit.queue if g.name == "measure"]
+    assert len(measure_gates) >= 1
+    measured_qubits = set()
+    for g in measure_gates:
+        measured_qubits.update(g.target_qubits)
+    expected = set(range(problem.m + problem.n))
+    assert measured_qubits == expected
+
+
+def test_invalid_ell():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        dqi_circuit(problem, ell=0)
+    with pytest.raises(ValueError):
+        dqi_circuit(problem, ell=problem.m + 1)
+
+
+def test_circuit_rejects_decoder_for_different_problem():
+    """dqi_circuit must reject a pre-built decoder bound to a different
+    MaxXORSAT instance (would silently build a wrong circuit)."""
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem_a = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    problem_b = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=1)
+    decoder_for_a = LUTDecoder(problem_a, ell=2)
+    with pytest.raises(ValueError):
+        dqi_circuit(problem_b, ell=2, decoder=decoder_for_a)
+
+
+def test_circuit_rejects_decoder_with_different_ell():
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    decoder_ell2 = LUTDecoder(problem, ell=2)
+    with pytest.raises(ValueError):
+        dqi_circuit(problem, ell=3, decoder=decoder_ell2)
+
+
+def test_circuit_executes(backend):
+    """Circuit runs under the numpy backend and produces (m + n)-bit samples."""
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    circuit = dqi_circuit(problem, ell=2)
+    result = backend.execute_circuit(circuit, nshots=16)
+    samples = np.asarray(result.samples(binary=True), dtype=np.uint8)
+    assert samples.shape == (16, problem.m + problem.n)
+
+
+def test_b_dependence_regression():
+    """Two MaxXORSAT instances with same m, s but different B must produce different states.
+
+    This is the regression for the original P0 bug: the buggy circuit
+    didn't use B at all, and these two states were identical.
+    """
+    B1 = np.array([[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]], dtype=np.uint8)
+    B2 = np.array([[1, 0, 1, 0], [0, 1, 0, 1], [1, 1, 0, 0]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem1 = MaxXORSAT(B1, s)
+    problem2 = MaxXORSAT(B2, s)
+    c1 = dqi_circuit(problem1, ell=1, include_measurements=False)
+    c2 = dqi_circuit(problem2, ell=1, include_measurements=False)
+    state1 = c1().state()
+    state2 = c2().state()
+    assert np.linalg.norm(state1 - state2) > 1e-6
+
+
+def test_amplitudes_match_krawtchouk_formula_full_coverage():
+    """For an instance with full LUT coverage (no collisions), the
+    error-register-zero slice of the joint state matches the closed-form
+    Krawtchouk amplitude formula to 1e-10.
+
+    Construction: m=3, n=2, ell=1, B=[[1,0],[0,1],[1,1]]. The four
+    weight-<=1 errors {(0,0,0), (1,0,0), (0,1,0), (0,0,1)} map bijectively
+    onto {0,1}^2, so the LUT decoder is exact and the post-selection
+    succeeds with probability 1.
+
+    The DQI amplitude on x is (paper Eq. 25 + 27 + 22 + Krawtchouk
+    rewriting):
+
+        amp(x) = (1 / sqrt(2^n)) * sum_k (w_k / sqrt(C(m, k))) * K_k(|s + Bx|, m)
+    """
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    ell = 1
+    m, n = problem.m, problem.n
+    w = optimal_weights(m, ell)
+
+    circuit = dqi_circuit(problem, ell, include_measurements=False)
+    state = circuit().state()
+    n_register_amps = state[: 2**n]
+
+    expected = np.zeros(2**n, dtype=complex)
+    for x_int in range(2**n):
+        x_bits = [(x_int >> (n - 1 - j)) & 1 for j in range(n)]
+        x = np.array(x_bits, dtype=np.uint8)
+        Bx = (B @ x) % 2
+        d = int(np.sum(s ^ Bx))
+        amp = 0.0
+        for k in range(ell + 1):
+            amp += w[k] * _binary_krawtchouk(k, d, m) / math.sqrt(math.comb(m, k))
+        amp /= math.sqrt(2**n)
+        expected[x_int] = amp
+
+    assert np.allclose(n_register_amps, expected, atol=1e-10)
+    assert abs(np.linalg.norm(n_register_amps) - 1.0) < 1e-10
+
+
+@pytest.mark.parametrize(
+    "B,s,ell",
+    [
+        (
+            np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8),
+            np.array([1, 0, 1], dtype=np.uint8),
+            1,
+        ),
+        (
+            np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8),
+            np.array([0, 1, 1], dtype=np.uint8),
+            2,
+        ),
+        (
+            np.array([[1, 1, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]], dtype=np.uint8),
+            np.array([1, 0, 1, 0], dtype=np.uint8),
+            2,
+        ),
+    ],
+)
+def test_amplitudes_match_chosen_S_sum(B, s, ell):
+    """For arbitrary (B, s, ell), the error-register-zero slice of the
+    joint state matches the partial sum over LUT-chosen ``S`` (paper Eq.
+    34 with the perfect-decoder assumption replaced by the chosen-S
+    selection of the LUT).
+
+    For each LUT entry (y, S):
+        amp_partial(x) = (1 / sqrt(2^n))
+                         * sum_S (w_{|S|} / sqrt(C(m, |S|)))
+                                 * (-1)^{1_S . (s + Bx)}
+
+    where 1_S is the indicator vector of S. Stronger than the
+    Krawtchouk-polynomial test because it covers ell >= 2 with collisions.
+    """
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem = MaxXORSAT(B, s)
+    m, n = problem.m, problem.n
+    w = optimal_weights(m, ell)
+
+    decoder = LUTDecoder(problem, ell)
+    table = decoder.decode_table()
+    circuit = dqi_circuit(problem, ell, include_measurements=False)
+    state = circuit().state()
+    n_register_amps = state[: 2**n]
+
+    expected = np.zeros(2**n, dtype=complex)
+    for x_int in range(2**n):
+        x_bits = [(x_int >> (n - 1 - j)) & 1 for j in range(n)]
+        x = np.array(x_bits, dtype=np.uint8)
+        u = (s ^ ((B @ x) % 2)).astype(int)
+        amp = 0.0
+        for _, S in table:
+            k = int(S.sum())
+            sign = (-1) ** int((S.astype(int) * u).sum())
+            amp += sign * w[k] / math.sqrt(math.comb(m, k))
+        amp /= math.sqrt(2**n)
+        expected[x_int] = amp
+
+    assert np.allclose(n_register_amps, expected, atol=1e-10)

--- a/tests/test_dqi_decoders.py
+++ b/tests/test_dqi_decoders.py
@@ -60,6 +60,13 @@ def test_lut_too_many_error_patterns():
         LUTDecoder(problem, ell=10)
 
 
+@pytest.mark.parametrize("ell", [-1, 4])
+def test_lut_rejects_cutoff_outside_problem_size(ell):
+    problem = MaxXORSAT.random_sparse(n=3, m=3, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        LUTDecoder(problem, ell=ell)
+
+
 def test_decoder_registry():
     problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
     decoder = get_decoder("lut", problem, 2)

--- a/tests/test_dqi_decoders.py
+++ b/tests/test_dqi_decoders.py
@@ -1,0 +1,79 @@
+"""Tests for qiboopt.dqi.decoders."""
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.decoders import LUTDecoder, get_decoder
+from qiboopt.dqi.max_xorsat import MaxXORSAT
+
+
+def test_lut_table_entries_satisfy_syndrome_relation():
+    """Every (y, S) pair returned must satisfy y = B^T S (mod 2) and |S| <= ell."""
+    problem = MaxXORSAT.random_sparse(n=6, m=8, row_weight=2, seed=42)
+    ell = 2
+    decoder = LUTDecoder(problem, ell)
+    for y, S in decoder.decode_table():
+        assert y.shape == (problem.n,)
+        assert S.shape == (problem.m,)
+        assert int(S.sum()) <= ell
+        recomputed = (problem.B.T @ S) % 2
+        assert np.array_equal(recomputed, y)
+
+
+def test_lut_table_unique_y_per_entry():
+    """The table must have at most one S per syndrome y."""
+    problem = MaxXORSAT.random_sparse(n=6, m=8, row_weight=2, seed=42)
+    decoder = LUTDecoder(problem, ell=2)
+    seen = set()
+    for y, _ in decoder.decode_table():
+        key = tuple(y.tolist())
+        assert key not in seen
+        seen.add(key)
+
+
+def test_lut_is_exact_when_full_coverage():
+    """is_exact is True iff every weight-<=ell S has a distinct syndrome."""
+    # Construction with no collisions: m=3, n=2, ell=1 gives 1+3=4 syndromes
+    # and 4 unique error patterns mapping bijectively to {0,1}^2.
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([0, 0, 0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    decoder = LUTDecoder(problem, ell=1)
+    assert decoder.is_exact is True
+
+
+def test_lut_is_exact_false_when_collisions():
+    """The reviewer's example: m=3, n=2, ell=2 with B=[[1,0],[0,1],[1,1]]
+    has 7 weight-<=2 patterns mapping to only 4 syndromes — collisions
+    exist, so is_exact must be False."""
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([0, 0, 0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    decoder = LUTDecoder(problem, ell=2)
+    assert decoder.is_exact is False
+
+
+def test_lut_too_many_error_patterns():
+    """Decoder rejects instances whose enumeration exceeds the safety limit."""
+    problem = MaxXORSAT.random_sparse(n=4, m=30, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        LUTDecoder(problem, ell=10)
+
+
+def test_decoder_registry():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    decoder = get_decoder("lut", problem, 2)
+    assert isinstance(decoder, LUTDecoder)
+
+
+def test_unknown_decoder():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(KeyError):
+        get_decoder("nonexistent", problem, 2)
+
+
+def test_lut_no_runtime_decode_method():
+    """Confirm the old runtime decode(y) method is gone."""
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    decoder = LUTDecoder(problem, ell=2)
+    assert not hasattr(decoder, "decode")

--- a/tests/test_dqi_dicke.py
+++ b/tests/test_dqi_dicke.py
@@ -60,3 +60,25 @@ def test_dicke_circuit_qubit_count():
     w = optimal_weights(m, ell)
     circuit = dicke_circuit(m, ell, w)
     assert circuit.nqubits == m
+
+
+def test_weighted_dicke_rejects_wrong_weight_length():
+    with pytest.raises(ValueError):
+        weighted_dicke_amplitudes(4, 2, np.array([1.0, 0.0]))
+
+
+@pytest.mark.parametrize("ell", [0, 5])
+def test_weighted_dicke_rejects_invalid_cutoff(ell):
+    with pytest.raises(ValueError):
+        weighted_dicke_amplitudes(4, ell, np.ones(ell + 1))
+
+
+def test_weighted_dicke_rejects_above_dense_unitary_cap():
+    """The brute-force state preparation must fail loudly before huge unitaries."""
+    with pytest.raises(ValueError):
+        weighted_dicke_amplitudes(13, 1, np.ones(2))
+
+
+def test_weighted_dicke_rejects_zero_state():
+    with pytest.raises(ValueError):
+        weighted_dicke_amplitudes(4, 2, np.zeros(3))

--- a/tests/test_dqi_dicke.py
+++ b/tests/test_dqi_dicke.py
@@ -1,0 +1,62 @@
+"""Tests for qiboopt.dqi.dicke."""
+
+import math
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.dicke import (
+    _unitary_with_first_column,
+    dicke_circuit,
+    weighted_dicke_amplitudes,
+)
+from qiboopt.dqi.weights import optimal_weights
+
+
+def test_amplitudes_normalised():
+    w = optimal_weights(4, 2)
+    amps = weighted_dicke_amplitudes(4, 2, w)
+    assert amps.shape == (16,)
+    assert abs(np.linalg.norm(amps) - 1.0) < 1e-12
+
+
+@pytest.mark.parametrize("m,ell", [(3, 2), (4, 2), (5, 3)])
+def test_amplitudes_match_analytic(m, ell):
+    """Acceptance criterion 1.2: prepared amplitudes match analytic vector to 1e-10."""
+    w = optimal_weights(m, ell)
+    amps = weighted_dicke_amplitudes(m, ell, w)
+
+    # Recompute the analytic amplitude for every basis state.
+    expected = np.zeros(2**m, dtype=complex)
+    for state in range(2**m):
+        k = bin(state).count("1")
+        if k <= ell:
+            expected[state] = w[k] / math.sqrt(math.comb(m, k))
+    expected /= np.linalg.norm(expected)
+    assert np.allclose(amps, expected, atol=1e-10)
+
+
+def test_unitary_first_column():
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal(8) + 1j * rng.standard_normal(8)
+    v = v / np.linalg.norm(v)
+    U = _unitary_with_first_column(v)
+    assert np.allclose(U @ U.conj().T, np.eye(8), atol=1e-12)
+    assert np.allclose(U[:, 0], v, atol=1e-12)
+
+
+def test_dicke_circuit_state():
+    """Run the Dicke prep circuit and confirm its state matches the analytic amplitudes."""
+    m, ell = 4, 2
+    w = optimal_weights(m, ell)
+    amps = weighted_dicke_amplitudes(m, ell, w)
+    circuit = dicke_circuit(m, ell, w)
+    state = circuit().state()
+    assert np.allclose(state, amps, atol=1e-10)
+
+
+def test_dicke_circuit_qubit_count():
+    m, ell = 5, 3
+    w = optimal_weights(m, ell)
+    circuit = dicke_circuit(m, ell, w)
+    assert circuit.nqubits == m

--- a/tests/test_dqi_max_xorsat.py
+++ b/tests/test_dqi_max_xorsat.py
@@ -1,0 +1,151 @@
+"""Tests for qiboopt.dqi.max_xorsat."""
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.max_xorsat import MaxXORSAT
+
+
+def test_construction_and_shape():
+    B = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.uint8)
+    s = np.array([1, 0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    assert problem.n == 3
+    assert problem.m == 2
+
+
+def test_evaluate():
+    B = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.uint8)
+    s = np.array([1, 0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    # x=[1,0,0]: Bx=[1,0]=s, both sat → 2
+    assert problem.evaluate(np.array([1, 0, 0], dtype=np.uint8)) == 2
+    # x=[0,0,0]: Bx=[0,0]; s=[1,0]; only second sat → 1
+    assert problem.evaluate(np.array([0, 0, 0], dtype=np.uint8)) == 1
+    # x=[1,1,1]: Bx=[0,0]; s=[1,0]; only second sat → 1
+    assert problem.evaluate(np.array([1, 1, 1], dtype=np.uint8)) == 1
+
+
+def test_brute_force():
+    B = np.array([[1, 1, 0], [0, 1, 1], [1, 0, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    best_x, best_v = problem.brute_force()
+    assert best_v == 3
+    assert problem.evaluate(best_x) == 3
+
+
+def test_random_sparse_shape():
+    problem = MaxXORSAT.random_sparse(n=8, m=12, row_weight=3, seed=42)
+    assert problem.n == 8
+    assert problem.m == 12
+    assert (problem.B.sum(axis=1) == 3).all()
+
+
+def test_random_sparse_reproducible():
+    a = MaxXORSAT.random_sparse(n=8, m=12, row_weight=3, seed=42)
+    b = MaxXORSAT.random_sparse(n=8, m=12, row_weight=3, seed=42)
+    assert np.array_equal(a.B, b.B)
+    assert np.array_equal(a.s, b.s)
+
+
+def test_invalid_inputs():
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.zeros((2,), dtype=np.uint8), np.zeros((2,), dtype=np.uint8))
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.zeros((2, 3), dtype=np.uint8), np.zeros((3,), dtype=np.uint8))
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[2, 0], [0, 0]]), np.array([0, 0]))
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[1, 0], [0, 1]]), np.array([2, 0]))
+
+
+def test_to_qubo_round_trip_row_weight_2():
+    """For row weights 1 and 2, to_qubo + minimisation = max-XOR-SAT maximiser."""
+    B = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.uint8)
+    s = np.array([0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    qubo = problem.to_qubo()
+    # The QUBO objective should equal m - sat_count for every x.
+    for bits in [
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1),
+    ]:
+        x = np.array(bits, dtype=np.uint8)
+        sat = problem.evaluate(x)
+        cost = qubo.evaluate_f(list(bits))
+        assert cost == problem.m - sat, (bits, sat, cost)
+
+
+def test_to_qubo_unsupported_row_weight():
+    B = np.array([[1, 1, 1]], dtype=np.uint8)
+    s = np.array([0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    with pytest.raises(NotImplementedError):
+        problem.to_qubo()
+
+
+def test_rejects_non_integer_floats_in_B():
+    """Regression: non-integer floats must NOT silently truncate to uint8."""
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[1.9, 0.0]]), np.array([0]))
+
+
+def test_rejects_non_integer_floats_in_s():
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[1, 0]]), np.array([0.5]))
+
+
+def test_accepts_integer_valued_floats():
+    """Float arrays whose values are exactly integer should be accepted."""
+    problem = MaxXORSAT(np.array([[1.0, 0.0]]), np.array([1.0]))
+    assert problem.B.dtype == np.uint8
+    assert problem.s.dtype == np.uint8
+
+
+def test_evaluate_rejects_non_integer_floats():
+    """Regression: evaluate(x) must NOT silently coerce non-integer floats."""
+    problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
+    with pytest.raises(ValueError):
+        problem.evaluate(np.array([1.9, 0.0, 1.0]))
+
+
+def test_evaluate_rejects_out_of_range_integers():
+    """Values outside {0, 1} must be rejected after coercion."""
+    problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
+    with pytest.raises(ValueError):
+        problem.evaluate(np.array([2, 0, 1]))
+
+
+def test_evaluate_accepts_integer_valued_floats():
+    """Float values exactly equal to integers are valid."""
+    problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
+    # x=[1, 1, 0] : Bx = 1+1 = 0 (mod 2), s = 0, 1 sat -> 1.
+    assert problem.evaluate(np.array([1.0, 1.0, 0.0])) == 1
+
+
+@pytest.mark.parametrize("bad_value", [-255, 257, 256, -1, 2])
+def test_constructor_rejects_uint8_wraparound_values(bad_value):
+    """Regression: values that wrap to 0 or 1 modulo 256 must be rejected.
+
+    Before the fix, ``bad_value`` was cast to uint8 first and then checked,
+    so e.g. -255 (-> 1) and 257 (-> 1) silently passed.
+    """
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[bad_value, 0]]), np.array([0]))
+    with pytest.raises(ValueError):
+        MaxXORSAT(np.array([[1, 0]]), np.array([bad_value]))
+
+
+@pytest.mark.parametrize("bad_value", [-255, 257, 256, -1, 2])
+def test_evaluate_rejects_uint8_wraparound_values(bad_value):
+    """Regression for the same wraparound issue, on evaluate(x)."""
+    problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
+    with pytest.raises(ValueError):
+        problem.evaluate(np.array([bad_value, 0, 0]))

--- a/tests/test_dqi_max_xorsat.py
+++ b/tests/test_dqi_max_xorsat.py
@@ -173,7 +173,9 @@ def test_evaluate_rejects_uint8_wraparound_values(bad_value):
 
 def test_brute_force_rejects_large_variable_count():
     """Exhaustive search is deliberately capped before 2**n becomes excessive."""
-    problem = MaxXORSAT(np.zeros((1, 21), dtype=np.uint8), np.array([0], dtype=np.uint8))
+    problem = MaxXORSAT(
+        np.zeros((1, 21), dtype=np.uint8), np.array([0], dtype=np.uint8)
+    )
     with pytest.raises(ValueError):
         problem.brute_force()
 

--- a/tests/test_dqi_max_xorsat.py
+++ b/tests/test_dqi_max_xorsat.py
@@ -53,6 +53,8 @@ def test_invalid_inputs():
     with pytest.raises(ValueError):
         MaxXORSAT(np.zeros((2,), dtype=np.uint8), np.zeros((2,), dtype=np.uint8))
     with pytest.raises(ValueError):
+        MaxXORSAT(np.zeros((2, 3), dtype=np.uint8), np.zeros((2, 1), dtype=np.uint8))
+    with pytest.raises(ValueError):
         MaxXORSAT(np.zeros((2, 3), dtype=np.uint8), np.zeros((3,), dtype=np.uint8))
     with pytest.raises(ValueError):
         MaxXORSAT(np.array([[2, 0], [0, 0]]), np.array([0, 0]))
@@ -81,6 +83,18 @@ def test_to_qubo_round_trip_row_weight_2():
         sat = problem.evaluate(x)
         cost = qubo.evaluate_f(list(bits))
         assert cost == problem.m - sat, (bits, sat, cost)
+
+
+def test_to_qubo_round_trip_row_weight_1_targets():
+    """Unit clauses become linear penalties for violating x_j = target."""
+    B = np.array([[1, 0], [0, 1]], dtype=np.uint8)
+    s = np.array([0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    qubo = problem.to_qubo(scale=2.0)
+
+    for bits in [(0, 0), (0, 1), (1, 0), (1, 1)]:
+        x = np.array(bits, dtype=np.uint8)
+        assert qubo.evaluate_f(list(bits)) == 2.0 * (problem.m - problem.evaluate(x))
 
 
 def test_to_qubo_unsupported_row_weight():
@@ -116,6 +130,12 @@ def test_evaluate_rejects_non_integer_floats():
         problem.evaluate(np.array([1.9, 0.0, 1.0]))
 
 
+def test_evaluate_rejects_wrong_shape():
+    problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
+    with pytest.raises(ValueError):
+        problem.evaluate(np.array([[1, 0, 1]], dtype=np.uint8))
+
+
 def test_evaluate_rejects_out_of_range_integers():
     """Values outside {0, 1} must be rejected after coercion."""
     problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
@@ -149,3 +169,16 @@ def test_evaluate_rejects_uint8_wraparound_values(bad_value):
     problem = MaxXORSAT(np.array([[1, 1, 0]]), np.array([0]))
     with pytest.raises(ValueError):
         problem.evaluate(np.array([bad_value, 0, 0]))
+
+
+def test_brute_force_rejects_large_variable_count():
+    """Exhaustive search is deliberately capped before 2**n becomes excessive."""
+    problem = MaxXORSAT(np.zeros((1, 21), dtype=np.uint8), np.array([0], dtype=np.uint8))
+    with pytest.raises(ValueError):
+        problem.brute_force()
+
+
+@pytest.mark.parametrize("row_weight", [0, 5])
+def test_random_sparse_rejects_impossible_row_weight(row_weight):
+    with pytest.raises(ValueError):
+        MaxXORSAT.random_sparse(n=4, m=3, row_weight=row_weight, seed=0)

--- a/tests/test_dqi_solver.py
+++ b/tests/test_dqi_solver.py
@@ -1,0 +1,234 @@
+"""End-to-end tests for qiboopt.dqi.solver."""
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.max_xorsat import MaxXORSAT
+from qiboopt.dqi.solver import DQISolver
+
+
+def test_solver_basic():
+    """Tiny instance: DQI must find the brute-force optimum within 256 shots."""
+    B = np.array(
+        [[1, 1, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]],
+        dtype=np.uint8,
+    )
+    s = np.array([1, 0, 1, 0], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    _, bv = problem.brute_force()
+
+    solver = DQISolver(problem, ell=2, decoder="lut")
+    result = solver.solve(nshots=256)
+    assert result["best_value"] == bv
+    assert isinstance(result["is_dqi_exact"], bool)
+    assert 0.0 <= result["decoder_success_probability"] <= 1.0
+    assert 0.0 <= result["postselect_success_rate"] <= 1.0
+
+
+@pytest.mark.parametrize("seed", [42, 43, 44, 45, 46])
+def test_solver_random_sparse(seed):
+    """5 random instances: DQI matches brute force on at least 4 of 5 (after post-selection)."""
+    problem = MaxXORSAT.random_sparse(n=6, m=8, row_weight=2, seed=seed)
+    _, bv = problem.brute_force()
+    solver = DQISolver(problem, ell=2, decoder="lut")
+    result = solver.solve(nshots=512)
+    # Allow occasional miss from decoder-failure branches.
+    assert result["best_value"] >= bv - 1
+
+
+def test_dqi_concentrates_on_optimum():
+    """DQI's post-selected output puts more weight on the brute-force optimum
+    than uniform sampling would.
+
+    The original buggy implementation passed a "best of N shots" test
+    trivially; this requires the algorithm to actually concentrate
+    probability on near-optimal x. Margin is conservative (>= 2x uniform).
+    """
+    problem = MaxXORSAT.random_sparse(n=4, m=4, row_weight=2, seed=11)
+    bx, _ = problem.brute_force()
+    solver = DQISolver(problem, ell=2, decoder="lut")
+    out = solver.sample(nshots=2048)
+    if out["shots_kept"] == 0:
+        pytest.skip("No shots passed post-selection on this instance.")
+    matches = np.all(out["candidates"] == bx[None, :], axis=1).sum()
+    empirical = matches / out["shots_kept"]
+    uniform = 1.0 / 2**problem.n
+    assert (
+        empirical > 2 * uniform
+    ), f"empirical={empirical:.4f}, uniform={uniform:.4f}; expected >= 2x"
+
+
+def test_full_coverage_instance_is_dqi_exact():
+    """Full-coverage instance: every weight-<=ell S has a distinct syndrome,
+    so is_dqi_exact is True and decoder_success_probability is 1.0."""
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    solver = DQISolver(problem, ell=1, decoder="lut")
+    out = solver.sample(nshots=128)
+    assert out["is_dqi_exact"] is True
+    assert abs(out["decoder_success_probability"] - 1.0) < 1e-12
+    assert out["postselect_success_rate"] == 1.0
+    assert out["shots_kept"] == 128
+    assert out["candidates"].shape == (128, problem.n)
+
+
+def test_colliding_lut_marks_inexact():
+    """Reviewer's example: m=3, n=2, ell=2, B=[[1,0],[0,1],[1,1]] has 7
+    weight-<=2 S's mapping to only 4 syndromes, so the LUT has collisions
+    and ``is_dqi_exact`` should be False. The analytic
+    ``decoder_success_probability`` matches the empirical
+    ``postselect_success_rate`` to within sampling noise.
+    """
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    solver = DQISolver(problem, ell=2, decoder="lut")
+    assert solver.is_dqi_exact is False
+    # Analytical value is exactly 5/7 for this instance (chosen S weights
+    # 0, 1, 1, 1 give w_0^2 + w_1^2 = 1 - w_2^2 = 5/7).
+    analytic = solver.decoder_success_probability
+    assert analytic < 1.0
+    out = solver.sample(nshots=4096)
+    empirical = out["postselect_success_rate"]
+    # Empirical should track the analytic prediction within standard
+    # sampling-noise bounds (~3 sigma for a Bernoulli at p~0.7, n=4096
+    # gives sigma ~= 0.007, so 0.05 is generous).
+    assert abs(empirical - analytic) < 0.05
+
+
+def test_invalid_ell():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=problem.m + 1)
+
+
+def test_invalid_nshots():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    solver = DQISolver(problem, ell=2)
+    with pytest.raises(ValueError):
+        solver.sample(0)
+    with pytest.raises(ValueError):
+        solver.sample(-1)
+
+
+def test_sample_returns_expected_keys():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    solver = DQISolver(problem, ell=2)
+    out = solver.sample(nshots=16)
+    assert set(out.keys()) >= {
+        "candidates",
+        "raw_samples",
+        "postselect_success_rate",
+        "decoder_success_probability",
+        "is_dqi_exact",
+        "shots",
+        "shots_kept",
+    }
+    assert out["shots"] == 16
+    assert out["raw_samples"].shape == (16, problem.m + problem.n)
+
+
+def test_unnormalized_weights_give_valid_probability():
+    """Regression: passing weights = 2 * optimal_weights must NOT report
+    decoder_success_probability above 1.
+
+    Previously the analytic formula used the raw self.weights while the
+    circuit auto-normalised; passing 2x weights reported 4.0 vs empirical
+    1.0. Solver now normalises weights at construction.
+    """
+    from qiboopt.dqi.weights import optimal_weights
+
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    w_opt = optimal_weights(problem.m, ell=1)
+
+    solver = DQISolver(problem, ell=1, weights=2 * w_opt)
+    assert solver.decoder_success_probability <= 1.0 + 1e-10
+    assert solver.decoder_success_probability >= 0.0
+    out = solver.sample(nshots=256)
+    # Full-coverage instance: empirical post-select rate is 1.0.
+    assert out["postselect_success_rate"] == 1.0
+    assert abs(solver.decoder_success_probability - 1.0) < 1e-10
+
+
+def test_solver_rejects_zero_norm_weights():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=2, weights=np.zeros(3))
+
+
+def test_solver_rejects_complex_weights_with_imaginary():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=2, weights=np.array([1.0 + 1j, 0.5, 0.0]))
+
+
+def test_solver_rejects_wrong_length_weights():
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=2, weights=np.array([1.0, 0.5]))  # length 2, expected 3
+
+
+def test_solver_rejects_nan_weights():
+    """Regression: NaN weights produce NaN diagnostics — must raise instead."""
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=2, weights=np.array([np.nan, 1.0, 0.0]))
+
+
+def test_solver_rejects_inf_weights():
+    """Regression: Inf weights produce a degenerate normalized vector."""
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=2, weights=np.array([np.inf, 1.0, 0.0]))
+
+
+def test_solver_rejects_decoder_built_for_different_B():
+    """A pre-built decoder bound to a different problem (different B,
+    same shape) silently builds the wrong DQI circuit. Must raise."""
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem_a = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    problem_b = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=1)
+    decoder_for_a = LUTDecoder(problem_a, ell=2)
+    with pytest.raises(ValueError):
+        DQISolver(problem_b, ell=2, decoder=decoder_for_a)
+
+
+def test_solver_rejects_decoder_built_for_different_ell():
+    """A pre-built decoder with a different ell must be rejected."""
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    decoder_ell2 = LUTDecoder(problem, ell=2)
+    with pytest.raises(ValueError):
+        DQISolver(problem, ell=3, decoder=decoder_ell2)
+
+
+def test_solver_accepts_decoder_for_structurally_equal_problem():
+    """A decoder built for an equal-but-different MaxXORSAT instance is
+    accepted (structural equality, not identity)."""
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem_orig = MaxXORSAT(B, s)
+    problem_copy = MaxXORSAT(B.copy(), s.copy())
+    decoder = LUTDecoder(problem_orig, ell=1)
+    # Must not raise:
+    solver = DQISolver(problem_copy, ell=1, decoder=decoder)
+    assert solver.decoder is decoder
+
+
+def test_solver_accepts_decoder_for_identical_problem():
+    """A decoder built for the same problem object is accepted (identity match)."""
+    from qiboopt.dqi.decoders import LUTDecoder
+
+    problem = MaxXORSAT.random_sparse(n=4, m=6, row_weight=2, seed=0)
+    decoder = LUTDecoder(problem, ell=2)
+    solver = DQISolver(problem, ell=2, decoder=decoder)
+    assert solver.decoder is decoder

--- a/tests/test_dqi_solver.py
+++ b/tests/test_dqi_solver.py
@@ -131,6 +131,29 @@ def test_sample_returns_expected_keys():
     assert out["raw_samples"].shape == (16, problem.m + problem.n)
 
 
+def test_sample_applies_noise_model_hook():
+    """A supplied noise model is applied to the constructed DQI circuit before execution."""
+
+    class IdentityNoiseModel:
+        def __init__(self):
+            self.applied_to = []
+
+        def apply(self, circuit):
+            self.applied_to.append(circuit.nqubits)
+            return circuit
+
+    B = np.array([[1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+    s = np.array([1, 0, 1], dtype=np.uint8)
+    problem = MaxXORSAT(B, s)
+    noise_model = IdentityNoiseModel()
+    solver = DQISolver(problem, ell=1, noise_model=noise_model)
+
+    out = solver.sample(nshots=8)
+
+    assert noise_model.applied_to == [problem.m + problem.n]
+    assert out["raw_samples"].shape == (8, problem.m + problem.n)
+
+
 def test_unnormalized_weights_give_valid_probability():
     """Regression: passing weights = 2 * optimal_weights must NOT report
     decoder_success_probability above 1.

--- a/tests/test_dqi_weights.py
+++ b/tests/test_dqi_weights.py
@@ -1,0 +1,55 @@
+"""Tests for qiboopt.dqi.weights."""
+
+import numpy as np
+import pytest
+
+from qiboopt.dqi.weights import optimal_weights
+
+
+def test_basic_shape():
+    w = optimal_weights(8, 3)
+    assert w.shape == (4,)
+
+
+def test_unit_norm():
+    for m, ell in [(4, 2), (8, 3), (12, 4), (16, 5)]:
+        w = optimal_weights(m, ell)
+        assert abs(np.linalg.norm(w) - 1.0) < 1e-12
+
+
+def test_sign_convention():
+    """Acceptance criterion 1.6: w[0] > 0 by convention."""
+    for m, ell in [(4, 2), (6, 3), (8, 3), (10, 4)]:
+        w = optimal_weights(m, ell)
+        assert w[0] > 0, f"w[0]={w[0]} should be positive for m={m}, ell={ell}"
+
+
+@pytest.mark.parametrize(
+    "m,ell",
+    [(4, 2), (6, 3), (8, 3)],
+)
+def test_matches_dense_eig(m, ell):
+    """Acceptance criterion 1.1: match dense numpy eigvec to 1e-10."""
+    w = optimal_weights(m, ell)
+
+    # Build the dense tridiagonal matrix and solve via numpy.
+    A = np.zeros((ell + 1, ell + 1))
+    for k in range(ell):
+        A[k, k + 1] = A[k + 1, k] = np.sqrt((k + 1) * (m - k))
+    eigvals, eigvecs = np.linalg.eigh(A)
+    expected = eigvecs[:, -1]
+    if expected[0] < 0:
+        expected = -expected
+
+    assert np.allclose(w, expected, atol=1e-10)
+
+
+def test_invalid_args():
+    with pytest.raises(TypeError):
+        optimal_weights(4.0, 2)
+    with pytest.raises(ValueError):
+        optimal_weights(0, 2)
+    with pytest.raises(ValueError):
+        optimal_weights(4, 0)
+    with pytest.raises(ValueError):
+        optimal_weights(4, 5)


### PR DESCRIPTION
## Summary

Adds a Phase 1 implementation of **Decoded Quantum Interferometry (DQI)**, the non-variational quantum optimisation algorithm of Jordan et al., *Optimization by Decoded Quantum Interferometry*, [arXiv:2408.08292](https://arxiv.org/abs/2408.08292) (v5), *Nature* **646**:831–836 (2025).

DQI takes a max-LIN / max-XOR-SAT instance over GF(2) and produces samples concentrated on near-optimal solutions. This is a fundamentally different paradigm from the QAOA/XQAOA path that the rest of `qiboopt` is built on, so it lives in a sibling `src/qiboopt/dqi/` module rather than as a method on `QUBO`.

## What's added

New package `src/qiboopt/dqi/` with:

- **`MaxXORSAT`** (`max_xorsat.py`) — problem class wrapping `(B, s)` with helpers for evaluating Hamming distance to the target.
- **`optimal_weights`** (`weights.py`) — principal eigenvector of the tridiagonal matrix from Theorem 3.4 / Eq. 70 of the paper.
- **`weighted_dicke_amplitudes` / `dicke_circuit`** (`dicke.py`) — brute-force amplitude-encoded weighted Dicke superposition on the error register.
- **`dqi_circuit`** (`circuit.py`) — full `m + n` qubit DQI circuit following §8.1.2: weighted Dicke prep → `Z^{s_i}` phasing → CNOT network for `B^T y` → in-circuit syndrome decoder → Hadamard transform on the solution register.
- **`SyndromeDecoder` / `LUTDecoder` / `get_decoder`** (`decoders/`) — pluggable decoder API, with a brute-force lookup-table decoder as the Phase 1 implementation.
- **`DQISolver`** (`solver.py`) — end-to-end solver with error-register post-selection on `|0^m⟩`, plus `is_dqi_exact` and `decoder_success_probability` diagnostics that make LUT-collision behaviour observable.
- Sphinx page at `doc/source/api-reference/dqi.rst`, registered in the API index.
- `scipy ^1.13` added as a direct dependency (used by the tridiagonal eigenproblem in `weights.py`).
- `qiboopt.dqi` re-exported from the top-level package.

Tests added for circuit construction, decoders, Dicke prep, `MaxXORSAT`, the weight vector, and end-to-end solver behaviour.

## Phase 1 limitations (called out in the docs)

- Practical only for `m + n ≤ 16` on a state-vector simulator.
- Brute-force Dicke prep materialises a dense `2^m × 2^m` unitary and is hard-capped at `m = 12`. Replacing this with a count-register + Bärtschi–Eidenbenz construction is left to a future phase.
- No `solve_dqi` entry point on `QUBO`; most QUBOs are not faithfully expressible as max-LIN, and we don't want to imply a generic-dense speedup.

## Out of scope for this PR

- Non-LUT decoders (BP, Gauss–Jordan, greedy).
- Count-register Dicke prep.
- Noise-model studies.