### PR TITLE
fix inconsistency in the objective function evaluation over different mode.

### DIFF
--- a/src/qiboopt/integrations/qiboml_adapter.py
+++ b/src/qiboopt/integrations/qiboml_adapter.py
@@ -94,7 +94,6 @@ def optimize_qaoa_with_qiboml(
         noise_model=noise_model,
         backend=backend,
     )
-    energy_shift = _energy_shift(qubo)
 
     diff_class = _get_differentiation_class(differentiation)
     model = QuantumModel(
@@ -134,7 +133,7 @@ def optimize_qaoa_with_qiboml(
         loss = model()
         if loss.ndim > 0:
             loss = loss.squeeze()
-        loss_value = float(loss.detach().cpu().item()) + energy_shift
+        loss_value = float(loss.detach().cpu().item())
         losses.append(loss_value)
         if loss_value < best:
             best = loss_value

--- a/src/qiboopt/opt_class/opt_class.py
+++ b/src/qiboopt/opt_class/opt_class.py
@@ -266,12 +266,21 @@ class QUBO:
         constant = self.offset
 
         for (u, v), bias in self.Qdict.items():
-            if bias:
+            if not bias:
+                continue
+
+            if u == v:
+                # x_i = (1 - s_i)/2  =>  bias * x_i contributes:
+                # constant += bias/2, h_i += -bias/2
+                constant += bias / 2
+                h[u] = h.get(u, 0.0) - bias / 2
+            else:
+                # x_u x_v = (1 - s_u - s_v + s_u s_v)/4
                 constant += bias / 4
-                h[u] = h.get(u, 0) - bias / 4
-                h[v] = h.get(v, 0) - bias / 4
-                if u != v:
-                    J[u, v] = bias / 4
+                h[u] = h.get(u, 0.0) - bias / 4
+                h[v] = h.get(v, 0.0) - bias / 4
+                J[u, v] = J.get((u, v), 0.0) + bias / 4
+
         return h, J, constant
 
     def construct_symbolic_Hamiltonian_from_QUBO(self):
@@ -883,6 +892,7 @@ class QUBO:
         # Create the Ising Hamiltonian using Qibo
         symbolic_ham = sum(h[i] * Z(i) for i in h)
         symbolic_ham += sum(value * Z(u) * Z(v) for (u, v), value in J.items())
+        symbolic_ham += _constant
 
         # Define the QAOA model
         hamiltonian = SymbolicHamiltonian(symbolic_ham)

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -720,7 +720,7 @@ def test_qubo_energy_paths_consistency_single_qubit():
 @pytest.mark.skipif(not _qiboml_available(), reason="qiboml/torch not installed")
 def test_qiboml_energy_consistency_with_direct_evaluation():
     """The qiboml path should return energies consistent with direct QUBO evaluation."""
-    # Simple 2-qubit QUBO: f(x0, x1) = x0 + x1 + x0*x1
+    # Simple 2-qubit QUBO: f(x0, x1) = 10 + x0 + x1 + x0*x1
     # f(0,0)=0, f(1,0)=1, f(0,1)=1, f(1,1)=3
     qp = QUBO(0.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
     all_values = [qp.evaluate_f([x0, x1]) for x0 in (0, 1) for x1 in (0, 1)]

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -721,7 +721,7 @@ def test_qubo_energy_paths_consistency_single_qubit():
 def test_qiboml_energy_consistency_with_direct_evaluation():
     """The qiboml path should return energies consistent with direct QUBO evaluation."""
     # Simple 2-qubit QUBO: f(x0, x1) = 10 + x0 + x1 + x0*x1
-    # f(0,0)=0, f(1,0)=1, f(0,1)=1, f(1,1)=3
+    # f(0,0)=10, f(1,0)=11, f(0,1)=11, f(1,1)=13; Ising constant = 11.25
     qp = QUBO(10.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
     all_values = [qp.evaluate_f([x0, x1]) for x0 in (0, 1) for x1 in (0, 1)]
     min_f = min(all_values)

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -722,7 +722,7 @@ def test_qiboml_energy_consistency_with_direct_evaluation():
     """The qiboml path should return energies consistent with direct QUBO evaluation."""
     # Simple 2-qubit QUBO: f(x0, x1) = 10 + x0 + x1 + x0*x1
     # f(0,0)=0, f(1,0)=1, f(0,1)=1, f(1,1)=3
-    qp = QUBO(0.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
+    qp = QUBO(10.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
     all_values = [qp.evaluate_f([x0, x1]) for x0 in (0, 1) for x1 in (0, 1)]
     min_f = min(all_values)
     max_f = max(all_values)

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -3,7 +3,7 @@ import itertools
 
 import numpy as np
 import pytest
-from qibo import Circuit, gates
+from qibo import Circuit, gates, get_backend, set_backend
 from qibo.models import QAOA
 from qibo.noise import DepolarizingError, NoiseModel
 from qibo.optimizers import optimize
@@ -657,6 +657,64 @@ def test_qubo_to_qaoa_object_params():
 
     assert isinstance(qaoa, QAOA)
     assert hasattr(qaoa, "hamiltonian")
+
+
+def test_qubo_energy_paths_consistency_single_qubit():
+    """Regression test for energy consistency across sampled/symbolic/exact paths.
+
+    QUBO: f(x) = x  => f(0)=0, f(1)=1
+    State prepared: |1>
+    """
+    set_backend("numpy")
+    backend = get_backend()
+
+    qubo = QUBO(0.0, {(0, 0): 1.0})
+
+    # Prepare |1> and measure
+    circ = Circuit(1)
+    circ.add(gates.X(0))
+    circ.add(gates.M(0))
+
+    nshots = 1000
+    freqs = backend.execute_circuit(circ, nshots=nshots).frequencies(binary=True)
+    sampled = (
+        sum(
+            qubo.evaluate_f([int(b) for b in bitstr]) * count
+            for bitstr, count in freqs.items()
+        )
+        / nshots
+    )
+
+    # Prepare |1> without measurement for expectation values
+    circ_no_m = Circuit(1)
+    circ_no_m.add(gates.X(0))
+
+    ham_expect = float(
+        qubo.construct_symbolic_Hamiltonian_from_QUBO().expectation(circ_no_m)
+    )
+    exact_loss = float(qubo.qubo_to_qaoa_object().hamiltonian.expectation(circ_no_m))
+
+    true_f1 = qubo.evaluate_f([1])
+
+    # Keep the original diagnostic values visible in pytest output on failure
+    debug_msg = (
+        f"\ntrue f(1)          : {true_f1}\n"
+        f"[A] sampled        : {sampled}\n"
+        f"[B] H expectation  : {ham_expect}\n"
+        f"[C] exact-mode loss: {exact_loss}\n"
+        f"qubo_to_ising      : {qubo.qubo_to_ising()}\n"
+    )
+
+    # Ground truth check
+    assert true_f1 == 1.0, debug_msg
+
+    # Sampling path should match ground truth for this deterministic preparation
+    assert sampled == pytest.approx(1.0, abs=1e-12), debug_msg
+
+    # The next two assertions enforce consistency goals.
+    # If current implementation is inconsistent, these will fail and expose the gap.
+    assert ham_expect == pytest.approx(true_f1, abs=1e-12), debug_msg
+    assert exact_loss == pytest.approx(true_f1, abs=1e-12), debug_msg
 
 
 def test_linear_initialization():

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -719,8 +719,7 @@ def test_qubo_energy_paths_consistency_single_qubit():
 
 @pytest.mark.skipif(not _qiboml_available(), reason="qiboml/torch not installed")
 def test_qiboml_energy_consistency_with_direct_evaluation():
-    """The qiboml path should return energies consistent with direct QUBO evaluation.
-    """
+    """The qiboml path should return energies consistent with direct QUBO evaluation."""
     # Simple 2-qubit QUBO: f(x0, x1) = x0 + x1 + x0*x1
     # f(0,0)=0, f(1,0)=1, f(0,1)=1, f(1,1)=3
     qp = QUBO(0.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
@@ -746,9 +745,10 @@ def test_qiboml_energy_consistency_with_direct_evaluation():
 
     # All losses in the history should also be within QUBO range.
     for i, loss in enumerate(extra["loss_history"]):
-        assert min_f <= loss <= max_f, (
-            f"loss_history[{i}]={loss:.6f} is outside the QUBO range [{min_f}, {max_f}]."
-        )
+        assert (
+            min_f <= loss <= max_f
+        ), f"loss_history[{i}]={loss:.6f} is outside the QUBO range [{min_f}, {max_f}]."
+
 
 def test_linear_initialization():
     A = np.array([[1, 2], [3, 4]])

--- a/tests/test_opt_class.py
+++ b/tests/test_opt_class.py
@@ -717,6 +717,39 @@ def test_qubo_energy_paths_consistency_single_qubit():
     assert exact_loss == pytest.approx(true_f1, abs=1e-12), debug_msg
 
 
+@pytest.mark.skipif(not _qiboml_available(), reason="qiboml/torch not installed")
+def test_qiboml_energy_consistency_with_direct_evaluation():
+    """The qiboml path should return energies consistent with direct QUBO evaluation.
+    """
+    # Simple 2-qubit QUBO: f(x0, x1) = x0 + x1 + x0*x1
+    # f(0,0)=0, f(1,0)=1, f(0,1)=1, f(1,1)=3
+    qp = QUBO(0.0, {(0, 0): 1.0, (1, 1): 1.0, (0, 1): 1.0})
+    all_values = [qp.evaluate_f([x0, x1]) for x0 in (0, 1) for x1 in (0, 1)]
+    min_f = min(all_values)
+    max_f = max(all_values)
+
+    best, params, extra, circuit, freqs = qp.train_QAOA(
+        gammas=[0.1],
+        betas=[0.2],
+        nshots=500,
+        engine="qiboml",
+        optimizer="adam",
+        lr=0.05,
+        epochs=5,
+    )
+
+    # The best loss must fall within [min_f, max_f]; a constant offset would push it outside.
+    assert min_f <= best <= max_f, (
+        f"qiboml best={best:.6f} is outside the QUBO range [{min_f}, {max_f}]. "
+        "This likely means an extra energy_shift is being applied."
+    )
+
+    # All losses in the history should also be within QUBO range.
+    for i, loss in enumerate(extra["loss_history"]):
+        assert min_f <= loss <= max_f, (
+            f"loss_history[{i}]={loss:.6f} is outside the QUBO range [{min_f}, {max_f}]."
+        )
+
 def test_linear_initialization():
     A = np.array([[1, 2], [3, 4]])
     b = np.array([5, 6])


### PR DESCRIPTION
This PR is to fix the inconsistency of the energy value when we use Ising or QAOA object directly. 

The energy was shifted by a constant previously:

- When we convert from QUBO to Ising, when we handle the diagonal terms, the bias terms were subtracted twice. 
- When we use QAOA object, we dropped the constant term previously. 

We have fixed the inconsistency and included a pytest.